### PR TITLE
Fix download stem

### DIFF
--- a/apps/archiver/src/workers/createStemsArchive/createStemsArchive.ts
+++ b/apps/archiver/src/workers/createStemsArchive/createStemsArchive.ts
@@ -13,30 +13,11 @@ import {
 import path from 'path'
 import { WorkerServices } from '../services'
 import { createUtils } from './utils'
-import fetch from 'node-fetch'
 
 type StemsArchiveWorkerListener = WorkerListener<
   StemsArchiveJobData,
   StemsArchiveJobResult
 >
-
-const getRedirectUrl = async (url: string) => {
-  try {
-    const response = await fetch(url, {
-      method: 'GET',
-      redirect: 'manual'
-    })
-
-    if (response.status >= 300 && response.status < 400) {
-      const redirectUrl = response.headers.get('Location')
-      return redirectUrl ?? url
-    } else {
-      return url
-    }
-  } catch (error) {
-    throw new Error(`Fetch failed: ${(error as Error).message}`)
-  }
-}
 
 export const createStemsArchiveWorker = (services: WorkerServices) => {
   const { config, spaceManager, fs, sdk } = services
@@ -166,27 +147,22 @@ export const createStemsArchiveWorker = (services: WorkerServices) => {
       // Start all downloads immediately so we can await allSettled after a failure:
       // if one rejects, Promise.all would run the outer catch and removeTempFiles while
       // siblings are still writing — ENOENT on other WriteStreams and process crash.
+      // The API's /tracks/{id}/download endpoint already calls tryFindWorkingUrl
+      // to pick a content node mirror that actually serves this file, and
+      // responds with a 302 redirect to it. node-fetch follows 3xx by default,
+      // so we can just point downloadFile at the API URL and let it land on the
+      // verified-working host. Do NOT rewrite the host — forcing every download
+      // through a single node (e.g. creatornode2) bypasses that mirror selection
+      // and produces 404s on files that exist, just not on that node.
       const downloadPromises = filesToDownload.map(
         async (stem: { id: string; origFilename?: string }) => {
-          let url
-
-          const downloadUrl = await sdk.tracks.getTrackDownloadUrl({
+          const url = await sdk.tracks.getTrackDownloadUrl({
             trackId: stem.id,
             userId: hashedUserId,
             userSignature: signatureHeader,
             userData: messageHeader,
             filename: stem.origFilename ?? ''
           })
-
-          if (config.environment === 'prod') {
-            url = downloadUrl
-            const redirectUrl = await getRedirectUrl(downloadUrl)
-            const modifiedUrl = new URL(redirectUrl)
-            modifiedUrl.host = 'creatornode2.audius.co'
-            url = modifiedUrl.toString()
-          } else {
-            url = downloadUrl
-          }
 
           const filePath = path.join(jobTempDir, stem.origFilename ?? 'file')
           return downloadFile({


### PR DESCRIPTION
Root cause: In createStemsArchive.ts, the prod branch was following one redirect from sdk.tracks.getTrackDownloadUrl(...) and then rewriting the resulting URL's host to creatornode2.audius.co. That workaround was added in pedalboard commit 6a0ee59 ("Use storeall for archiver") when the old Python API returned a content-node URL directly.

The Go API now handles this itself: v1_track_download.go:53 calls tryFindWorkingUrl, which probes the primary URL and every mirror with Range: bytes=0-1 and returns a 302 to whichever host actually serves the bytes. Rewriting that already-verified host to creatornode2 sent requests to a node that may not hold the file at all → 404 on a file that exists.

Fix: Removed the getRedirectUrl helper, the node-fetch import, and the prod-only host rewrite. node-fetch follows 3xx by default, so we just pass the API URL to downloadFile and let the redirect land on the API's chosen mirror. The comment in the file explains why, so this doesn't get re-introduced.