### PR TITLE
Add contest follower push notifications

### DIFF
--- a/apps/notifications/src/processNotifications/indexAppNotifications.ts
+++ b/apps/notifications/src/processNotifications/indexAppNotifications.ts
@@ -111,7 +111,9 @@ export const notificationTypeMapping = {
     MappingVariable.PushArtistRemixContestEndingSoon,
   artist_remix_contest_submissions:
     MappingVariable.PushArtistRemixContestSubmissions,
-  fan_club_text_post: MappingVariable.PushFanClubTextPost
+  fan_club_text_post: MappingVariable.PushFanClubTextPost,
+  remix_contest_update: MappingVariable.PushRemixContestUpdate,
+  fan_remix_contest_submission: MappingVariable.PushFanRemixContestSubmission
 }
 
 export class AppNotificationsProcessor {

--- a/apps/notifications/src/processNotifications/mappers/fanRemixContestSubmission.ts
+++ b/apps/notifications/src/processNotifications/mappers/fanRemixContestSubmission.ts
@@ -1,0 +1,123 @@
+import { Knex } from 'knex'
+import { NotificationRow } from '../../types/dn'
+import { FanRemixContestSubmissionNotification } from '../../types/notifications'
+import { BaseNotification } from './base'
+import { sendPushNotification } from '../../sns'
+import {
+  buildUserNotificationSettings,
+  Device
+} from './userNotificationSettings'
+import { sendBrowserNotification } from '../../web'
+import { disableDeviceArns } from '../../utils/disableArnEndpoint'
+import { formatImageUrl } from '../../utils/format'
+
+export type FanRemixContestSubmissionRow = Omit<NotificationRow, 'data'> & {
+  data: FanRemixContestSubmissionNotification
+}
+
+export class FanRemixContestSubmission extends BaseNotification<FanRemixContestSubmissionRow> {
+  constructor(
+    dnDB: Knex,
+    identityDB: Knex,
+    notification: FanRemixContestSubmissionRow
+  ) {
+    super(dnDB, identityDB, notification)
+  }
+
+  async processNotification({
+    isBrowserPushEnabled
+  }: {
+    isBrowserPushEnabled: boolean
+  }) {
+    const userIds = this.notification.user_ids ?? []
+    if (!userIds.length) {
+      return
+    }
+
+    const submitterRes: Array<{ user_id: number; name: string }> = await this.dnDB
+      .select('user_id', 'name')
+      .from('users')
+      .where('is_current', true)
+      .whereIn('user_id', [this.notification.data.submitter_user_id])
+    const submitterName = submitterRes[0]?.name ?? 'Someone'
+
+    const trackRes: Array<{
+      track_id: number
+      title: string
+      cover_art_sizes?: string | null
+    }> = await this.dnDB
+      .select('track_id', 'title', 'cover_art_sizes')
+      .from('tracks')
+      .where('is_current', true)
+      .whereIn('track_id', [this.notification.data.entity_id])
+    const track = trackRes[0]
+    const trackName = track?.title ?? 'a contest'
+    const submissionTrackRes: Array<{ cover_art_sizes?: string | null }> =
+      await this.dnDB
+        .select('cover_art_sizes')
+        .from('tracks')
+        .where('is_current', true)
+        .whereIn('track_id', [this.notification.data.submission_track_id])
+    const submission = submissionTrackRes[0]
+
+    let imageUrl: string | undefined
+    if (submission?.cover_art_sizes) {
+      imageUrl = formatImageUrl(submission.cover_art_sizes, 150)
+    } else if (track?.cover_art_sizes) {
+      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+    }
+
+    const userNotificationSettings = await buildUserNotificationSettings(
+      this.identityDB,
+      userIds
+    )
+    const title = 'New contest submission'
+    const body = `${submitterName} submitted to ${trackName}`
+
+    for (const userId of userIds) {
+      await sendBrowserNotification(
+        isBrowserPushEnabled,
+        userNotificationSettings,
+        userId,
+        title,
+        body
+      )
+
+      if (
+        userNotificationSettings.shouldSendPushNotification({
+          receiverUserId: userId
+        })
+      ) {
+        const devices: Device[] = userNotificationSettings.getDevices(userId)
+        const pushes = await Promise.all(
+          devices.map((device) => {
+            return sendPushNotification(
+              {
+                type: device.type,
+                badgeCount: userNotificationSettings.getBadgeCount(userId) + 1,
+                targetARN: device.awsARN
+              },
+              {
+                title,
+                body,
+                data: {
+                  id: `timestamp:${this.getNotificationTimestamp()}:group_id:${
+                    this.notification.group_id
+                  }`,
+                  type: 'FanRemixContestSubmission',
+                  eventId: this.notification.data.event_id,
+                  entityId: this.notification.data.entity_id,
+                  entityUserId: this.notification.data.entity_user_id,
+                  submissionTrackId: this.notification.data.submission_track_id
+                },
+                imageUrl
+              }
+            )
+          })
+        )
+        await disableDeviceArns(this.identityDB, pushes)
+        await this.incrementBadgeCount(userId)
+      }
+    }
+  }
+}

--- a/apps/notifications/src/processNotifications/mappers/mapNotifications.ts
+++ b/apps/notifications/src/processNotifications/mappers/mapNotifications.ts
@@ -49,7 +49,9 @@ import {
   ArtistRemixContestEndingSoonNotification,
   ArtistRemixContestSubmissionsNotification,
   FanRemixContestWinnersSelectedNotification,
-  FanClubTextPostNotification
+  FanClubTextPostNotification,
+  RemixContestUpdateNotification,
+  FanRemixContestSubmissionNotification
 } from '../../types/notifications'
 import { ApproveManagerRequest } from './approveManagerRequest'
 import { Follow } from './follow'
@@ -95,6 +97,8 @@ import { ArtistRemixContestEndingSoon } from './artistRemixContestEndingSoon'
 import { ArtistRemixContestSubmissions } from './artistRemixContestSubmissions'
 import { FanClubTextPost } from './fanClubTextPost'
 import { FanRemixContestWinnersSelected } from './fanRemixContestWinnersSelected'
+import { FanRemixContestSubmission } from './fanRemixContestSubmission'
+import { RemixContestUpdate } from './remixContestUpdate'
 
 export const mapNotifications = (
   notifications: (NotificationRow | EmailNotification)[],
@@ -403,6 +407,20 @@ const mapNotification = (
       data: FanClubTextPostNotification
     }
     return new FanClubTextPost(dnDb, identityDb, fanClubTextPostNotification)
+  } else if (notification.type == 'remix_contest_update') {
+    const remixContestUpdateNotif = notification as NotificationRow & {
+      data: RemixContestUpdateNotification
+    }
+    return new RemixContestUpdate(dnDb, identityDb, remixContestUpdateNotif)
+  } else if (notification.type == 'fan_remix_contest_submission') {
+    const fanRemixContestSubmissionNotif = notification as NotificationRow & {
+      data: FanRemixContestSubmissionNotification
+    }
+    return new FanRemixContestSubmission(
+      dnDb,
+      identityDb,
+      fanRemixContestSubmissionNotif
+    )
   }
   logger.info(`Notification type: ${notification.type} has no handler`)
 }

--- a/apps/notifications/src/processNotifications/mappers/remixContestUpdate.ts
+++ b/apps/notifications/src/processNotifications/mappers/remixContestUpdate.ts
@@ -1,0 +1,129 @@
+import { Knex } from 'knex'
+import { NotificationRow } from '../../types/dn'
+import { RemixContestUpdateNotification } from '../../types/notifications'
+import { BaseNotification } from './base'
+import { sendPushNotification } from '../../sns'
+import {
+  buildUserNotificationSettings,
+  Device
+} from './userNotificationSettings'
+import { sendBrowserNotification } from '../../web'
+import { disableDeviceArns } from '../../utils/disableArnEndpoint'
+import { formatImageUrl } from '../../utils/format'
+
+export type RemixContestUpdateRow = Omit<NotificationRow, 'data'> & {
+  data: RemixContestUpdateNotification
+}
+
+export class RemixContestUpdate extends BaseNotification<RemixContestUpdateRow> {
+  constructor(
+    dnDB: Knex,
+    identityDB: Knex,
+    notification: RemixContestUpdateRow
+  ) {
+    super(dnDB, identityDB, notification)
+  }
+
+  async processNotification({
+    isBrowserPushEnabled
+  }: {
+    isBrowserPushEnabled: boolean
+  }) {
+    const userIds = this.notification.user_ids ?? []
+    if (!userIds.length) {
+      return
+    }
+
+    const contestTrackId =
+      this.notification.data.entity_id ??
+      (
+        await this.dnDB
+          .select('entity_id')
+          .from('events')
+          .where('event_id', this.notification.data.event_id)
+          .first()
+      )?.entity_id
+
+    const hostRes: Array<{ user_id: number; name: string; profile_picture_sizes: string | null }> =
+      await this.dnDB
+        .select('user_id', 'name', 'profile_picture_sizes')
+        .from('users')
+        .where('is_current', true)
+        .whereIn('user_id', [this.notification.data.entity_user_id])
+    const hostName = hostRes[0]?.name ?? ''
+
+    const trackRes: Array<{
+      track_id: number
+      title: string
+      cover_art_sizes?: string | null
+    }> = contestTrackId
+      ? await this.dnDB
+          .select('track_id', 'title', 'cover_art_sizes')
+          .from('tracks')
+          .where('is_current', true)
+          .whereIn('track_id', [contestTrackId])
+      : []
+    const track = trackRes[0]
+    const trackName = track?.title ?? 'the contest'
+
+    let imageUrl: string | undefined
+    if (track?.cover_art_sizes) {
+      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+    } else if (hostRes[0]?.profile_picture_sizes) {
+      imageUrl = formatImageUrl(hostRes[0].profile_picture_sizes, 150)
+    }
+
+    const userNotificationSettings = await buildUserNotificationSettings(
+      this.identityDB,
+      userIds
+    )
+    const title = 'Contest update'
+    const body = `${hostName} posted an update in ${trackName}`
+
+    for (const userId of userIds) {
+      await sendBrowserNotification(
+        isBrowserPushEnabled,
+        userNotificationSettings,
+        userId,
+        title,
+        body
+      )
+
+      if (
+        userNotificationSettings.shouldSendPushNotification({
+          receiverUserId: userId
+        })
+      ) {
+        const devices: Device[] = userNotificationSettings.getDevices(userId)
+        const pushes = await Promise.all(
+          devices.map((device) => {
+            return sendPushNotification(
+              {
+                type: device.type,
+                badgeCount: userNotificationSettings.getBadgeCount(userId) + 1,
+                targetARN: device.awsARN
+              },
+              {
+                title,
+                body,
+                data: {
+                  id: `timestamp:${this.getNotificationTimestamp()}:group_id:${
+                    this.notification.group_id
+                  }`,
+                  type: 'RemixContestUpdate',
+                  eventId: this.notification.data.event_id,
+                  commentId: this.notification.data.comment_id,
+                  entityId: contestTrackId ?? 0,
+                  entityUserId: this.notification.data.entity_user_id
+                },
+                imageUrl
+              }
+            )
+          })
+        )
+        await disableDeviceArns(this.identityDB, pushes)
+        await this.incrementBadgeCount(userId)
+      }
+    }
+  }
+}

--- a/apps/notifications/src/remoteConfig.ts
+++ b/apps/notifications/src/remoteConfig.ts
@@ -50,7 +50,9 @@ export enum MappingVariable {
   PushFanRemixContestWinnersSelected = 'push_fan_remix_contest_winners_selected',
   PushArtistRemixContestEndingSoon = 'push_artist_remix_contest_ending_soon',
   PushArtistRemixContestSubmissions = 'push_artist_remix_contest_submissions',
-  PushFanClubTextPost = 'push_fan_club_text_post'
+  PushFanClubTextPost = 'push_fan_club_text_post',
+  PushRemixContestUpdate = 'push_remix_contest_update',
+  PushFanRemixContestSubmission = 'push_fan_remix_contest_submission'
 }
 
 export const NotificationsEmailPlugin = 'notification_email_plugin'
@@ -105,7 +107,9 @@ const defaultMappingVariable = {
   [MappingVariable.PushFanRemixContestWinnersSelected]: false,
   [MappingVariable.PushArtistRemixContestEndingSoon]: false,
   [MappingVariable.PushArtistRemixContestSubmissions]: false,
-  [MappingVariable.PushFanClubTextPost]: false
+  [MappingVariable.PushFanClubTextPost]: false,
+  [MappingVariable.PushRemixContestUpdate]: false,
+  [MappingVariable.PushFanRemixContestSubmission]: false
 }
 
 export const BrowserPushPlugin = 'browser_push_plugin'

--- a/apps/notifications/src/types/notifications.ts
+++ b/apps/notifications/src/types/notifications.ts
@@ -353,6 +353,21 @@ export type FanRemixContestWinnersSelectedNotification = {
   entity_user_id: number
 }
 
+export type RemixContestUpdateNotification = {
+  event_id: number
+  entity_id: number
+  entity_user_id: number
+  comment_id: number
+}
+
+export type FanRemixContestSubmissionNotification = {
+  event_id: number
+  entity_id: number
+  entity_user_id: number
+  submission_track_id: number
+  submitter_user_id: number
+}
+
 export type ArtistRemixContestEndingSoonNotification = {
   entity_id: number
   entity_user_id: number
@@ -412,6 +427,8 @@ export type NotificationData =
   | ArtistRemixContestEndingSoonNotification
   | ArtistRemixContestSubmissionsNotification
   | FanClubTextPostNotification
+  | RemixContestUpdateNotification
+  | FanRemixContestSubmissionNotification
 
 export class RequiresRetry extends Error {
   constructor(message: string) {


### PR DESCRIPTION
## Summary
- New push processors for `remix_contest_update` (host posts an update) and `fan_remix_contest_submission` (anyone submits to the contest)
- Wired through `mapNotifications`, `indexAppNotifications`, and `remoteConfig`
- Both gated behind Optimizely flags (`push_remix_contest_update`, `push_fan_remix_contest_submission`), defaulting off
- Pairs with api PR for the SQL/Go changes and apps-3 PR for the indexer + frontend

## Test plan
- [ ] After api + apps-3 land, write a `remix_contest_update` notification row in dev → confirm push fires with host name + contest title
- [ ] Same for `fan_remix_contest_submission` row → push fires with submitter name + contest title
- [ ] Tap on each push → opens the right destination (contest page / submitted remix)
- [ ] Confirm push is suppressed when the matching Optimizely flag is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)