### PR TITLE
Allow latest.yml to promote a single service

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -7,9 +7,14 @@ on:
         description: 'Commit SHA to tag as latest (defaults to main)'
         required: false
         type: string
+      service:
+        description: 'Service to promote (leave empty to promote all 13)'
+        required: false
+        type: string
 
 concurrency:
-  group: latest-release
+  # Single-service runs don't need to block multi-service runs and vice versa.
+  group: latest-release-${{ inputs.service || 'all' }}
   cancel-in-progress: false
 
 jobs:
@@ -22,10 +27,23 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
+
       - name: Setup services matrix
         id: setup-services
-        uses: ./.github/actions/setup-services-matrix
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.service }}" ]; then
+            # Validate the service exists in the canonical list before promoting.
+            if ! jq -e --arg s "${{ inputs.service }}" 'index($s) != null' .github/config/services.json > /dev/null; then
+              echo "Error: '${{ inputs.service }}' is not a known service. Allowed:" >&2
+              jq -r '.[]' .github/config/services.json >&2
+              exit 1
+            fi
+            SERVICES=$(jq -c -n --arg s "${{ inputs.service }}" '[$s]')
+          else
+            SERVICES=$(jq -c . .github/config/services.json)
+          fi
+          echo "services=$SERVICES" >> "$GITHUB_OUTPUT"
 
   # Verify edge images exist for the specified commit
   verify-edge:


### PR DESCRIPTION
## Summary

Adds an optional \`service\` input to the \`Release Latest\` workflow_dispatch. When set, only that service is retagged as \`:latest\`; when omitted, the existing whole-release behavior (all 13 services) is preserved.

Useful for mid-cycle hotfix promotions — e.g. promoting just the trending-challenge-rewards image after pinning the SDK to a Node-22-safe version, without retagging every other service that's currently mid-flight on \`main\`.

## Changes

- Add \`service\` workflow_dispatch input
- Replace the \`setup-services-matrix\` action call with inline matrix logic that respects the input
- Validate the service name against \`.github/config/services.json\` so typos fail fast
- Per-service-or-all concurrency group so single-service runs don't block whole-release runs

## Trigger

\`\`\`bash
# all 13 (existing behavior, unchanged)
gh workflow run latest.yml -R AudiusProject/pedalboard

# one service
gh workflow run latest.yml -R AudiusProject/pedalboard -f service=trending-challenge-rewards
\`\`\`

## Test plan

- [ ] Merge, then run with \`service=trending-challenge-rewards\` to verify single-service path
- [ ] Confirm next regular whole-release run still promotes all 13