### PR TITLE
Pass UPPER_SNAKE DB URLs explicitly to basekit initializers

### DIFF
--- a/apps/trending-challenge-rewards/src/utils.ts
+++ b/apps/trending-challenge-rewards/src/utils.ts
@@ -4,8 +4,8 @@ import {
 } from '@pedalboard/basekit'
 import { Err, Ok, Result } from 'ts-results'
 
-export const identityDb = initializeIdentityDb()
-export const discoveryDb = initializeDiscoveryDb()
+export const identityDb = initializeIdentityDb(process.env.IDENTITY_DB_URL)
+export const discoveryDb = initializeDiscoveryDb(process.env.AUDIUS_DB_URL)
 
 /// catches possibles errors and converts them to an appropriate result type
 /// this is useful when using a library that may throw and you want to catch it safely


### PR DESCRIPTION
## Summary

basekit's \`initializeDiscoveryDb\` / \`initializeIdentityDb\` only auto-read **lowercase** env vars (\`DN_DB_URL\`/\`audius_db_url\` and \`identity_db_url\`), then fall back to a docker-default that points at host \`db\` (the docker-compose service name).

With our UPPER_SNAKE convention (\`AUDIUS_DB_URL\`, \`IDENTITY_DB_URL\`), basekit's auto-reads return undefined and the default kicks in. In k8s there's no \`db\` host → \`getaddrinfo ENOTFOUND db\` on every DB query.

Fix is one line: pass our env vars explicitly to the initializers.

## Diff

\`\`\`
-export const identityDb = initializeIdentityDb()
-export const discoveryDb = initializeDiscoveryDb()
+export const identityDb = initializeIdentityDb(process.env.IDENTITY_DB_URL)
+export const discoveryDb = initializeDiscoveryDb(process.env.AUDIUS_DB_URL)
\`\`\`

## Required follow-up

- Add \`trending-challenge-rewards-IDENTITY_DB_URL\` to GSM (companion update to audius-k8s yaml is also needed — adds it to the secrets list).
🤖 Generated with [Claude Code](https://claude.com/claude-code)