### PR TITLE
Migrate TCR env vars back to lowercase

### DIFF
--- a/apps/trending-challenge-rewards/src/config.ts
+++ b/apps/trending-challenge-rewards/src/config.ts
@@ -37,22 +37,22 @@ export const initSharedData = async (): Promise<SharedData> => {
 
   sharedData = {
     sdk: audiusSdk({
-      environment: process.env.ENVIRONMENT as
+      environment: process.env.environment as
         | 'development'
         | 'production',
-      solanaRpcEndpoint: process.env.SOLANA_RPC_ENDPOINT,
-      solanaRelayNode: process.env.SOLANA_RELAY_NODE!
+      solanaRpcEndpoint: process.env.solana_rpc_endpoint,
+      solanaRelayNode: process.env.solana_relay_node!
     }),
     apiEndpoint: getApiEndpoint(
-      process.env.ENVIRONMENT as 'development' | 'production'
+      process.env.environment as 'development' | 'production'
     ),
-    runNow: process.env.RUN_NOW?.toLowerCase() === 'true',
-    dryRun: process.env.TCR_DRY_RUN?.toLowerCase() === 'true',
-    audiusDbUrl: process.env.AUDIUS_DB_URL!,
-    slackChannel: process.env.SLACK_CHANNEL,
-    slackSigningSecret: process.env.SLACK_SIGNING_SECRET,
-    slackBotToken: process.env.SLACK_BOT_TOKEN,
-    slackAppToken: process.env.SLACK_APP_TOKEN
+    runNow: process.env.run_now?.toLowerCase() === 'true',
+    dryRun: process.env.tcr_dry_run?.toLowerCase() === 'true',
+    audiusDbUrl: process.env.audius_db_url!,
+    slackChannel: process.env.slack_channel,
+    slackSigningSecret: process.env.slack_signing_secret,
+    slackBotToken: process.env.slack_bot_token,
+    slackAppToken: process.env.slack_app_token
   }
   return sharedData
 }

--- a/apps/trending-challenge-rewards/src/main.ts
+++ b/apps/trending-challenge-rewards/src/main.ts
@@ -20,8 +20,8 @@ const onDemandRun = async (app: App<SharedData>) => {
 
 export const main = async () => {
   const data = await initSharedData()
-  const port = process.env.PORT
-    ? parseInt(process.env.PORT, 10)
+  const port = process.env.port
+    ? parseInt(process.env.port, 10)
     : DEFAULT_PORT
 
   await new App<SharedData>({ appData: data })


### PR DESCRIPTION
## Summary

basekit's \`initializeDiscoveryDb\` / \`initializeIdentityDb\` auto-read **lowercase** env vars (\`DN_DB_URL\`/\`audius_db_url\`, \`identity_db_url\`) and fall back to a docker-default that points at host \`db\`. With our prior UPPER_SNAKE convention, basekit's auto-reads returned undefined and the default kicked in → \`ENOTFOUND db\` in k8s.

Rather than work around it by passing connection strings explicitly to basekit (extra code, fragile), align TCR's whole env-var convention with basekit's expectations.

## Changes

- \`config.ts\`: all \`process.env.<UPPER>\` → \`process.env.<lower>\` for the 12 env reads (\`environment\`, \`solana_*\`, \`audius_db_url\`, \`slack_*\`, \`run_now\`, \`tcr_dry_run\`).
- \`main.ts\`: \`process.env.PORT\` → \`process.env.port\`.
- No utils.ts changes needed — \`initializeDiscoveryDb()\` / \`initializeIdentityDb()\` with no args now picks up our lowercase values automatically.

## Companion changes (separate PR in audius-k8s)

The Pulumi yaml's secrets list also needs to flip to lowercase. GSM secrets must be re-created with lowercase keys (\`trending-challenge-rewards-audius_db_url\`, etc.). Old UPPER_SNAKE GSM entries can be disabled/destroyed after cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)