### PR TITLE
notifications: use 1000x1000 cover art for push notification images

### DIFF
--- a/apps/notifications/src/processNotifications/mappers/addTrackToPlaylist.ts
+++ b/apps/notifications/src/processNotifications/mappers/addTrackToPlaylist.ts
@@ -104,10 +104,10 @@ export class AddTrackToPlaylist extends BaseNotification<AddTrackToPlaylistNotif
     const title = 'Your track got on a playlist! 💿'
     const body = `${playlistOwnerName} added ${trackTitle} to their playlist ${playlistName}`
 
-    // Get playlist's image URL for rich notification (150x150 size)
+    // Get playlist's image URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     if (playlist?.playlist_image_sizes_multihash) {
-      imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+      imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
     }
 
     await sendBrowserNotification(

--- a/apps/notifications/src/processNotifications/mappers/artistRemixContestEnded.ts
+++ b/apps/notifications/src/processNotifications/mappers/artistRemixContestEnded.ts
@@ -35,7 +35,7 @@ export class ArtistRemixContestEnded extends BaseNotification<ArtistRemixContest
       return
     }
 
-    // Fetch track's cover art URL for rich notification (150x150 size)
+    // Fetch track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const trackRes: Array<{
       track_id: number
@@ -48,7 +48,7 @@ export class ArtistRemixContestEnded extends BaseNotification<ArtistRemixContest
       .whereIn('track_id', [this.notification.data.entity_id])
     const track = trackRes[0]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/artistRemixContestEndingSoon.ts
+++ b/apps/notifications/src/processNotifications/mappers/artistRemixContestEndingSoon.ts
@@ -34,7 +34,7 @@ export class ArtistRemixContestEndingSoon extends BaseNotification<ArtistRemixCo
       return
     }
 
-    // Fetch track name and cover art URL for rich notification (150x150 size)
+    // Fetch track name and cover art URL for rich notification (1000x1000 size)
     const trackRes: Array<{
       track_id: number
       title: string
@@ -49,7 +49,7 @@ export class ArtistRemixContestEndingSoon extends BaseNotification<ArtistRemixCo
 
     let imageUrl: string | undefined
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/artistRemixContestSubmissions.ts
+++ b/apps/notifications/src/processNotifications/mappers/artistRemixContestSubmissions.ts
@@ -38,7 +38,7 @@ export class ArtistRemixContestSubmissions extends BaseNotification<ArtistRemixC
       return
     }
 
-    // Fetch track name and cover art URL for rich notification (150x150 size)
+    // Fetch track name and cover art URL for rich notification (1000x1000 size)
     const trackRes: Array<{
       track_id: number
       title: string
@@ -53,7 +53,7 @@ export class ArtistRemixContestSubmissions extends BaseNotification<ArtistRemixC
 
     let imageUrl: string | undefined
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const {

--- a/apps/notifications/src/processNotifications/mappers/comment.ts
+++ b/apps/notifications/src/processNotifications/mappers/comment.ts
@@ -108,7 +108,7 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
       entityType = 'track'
       entityName = track?.title
       if (track?.cover_art_sizes) {
-        imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+        imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
       }
     } else if (
       this.entityType === EntityType.Playlist ||
@@ -143,7 +143,7 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
       entityType = playlist?.is_album ? 'album' : 'playlist'
       entityName = playlist?.playlist_name
       if (playlist?.playlist_image_sizes_multihash) {
-        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
       }
     } else if (this.entityType === EntityType.Event) {
       // Comment is on a contest. `entity_id` is the event_id; the underlying
@@ -165,7 +165,7 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
           entityType = 'contest'
           entityName = track.title
           if (track.cover_art_sizes) {
-            imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+            imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
           }
         }
       }

--- a/apps/notifications/src/processNotifications/mappers/commentMention.ts
+++ b/apps/notifications/src/processNotifications/mappers/commentMention.ts
@@ -64,7 +64,7 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
         entityType = 'track'
         entityName = title
         if (track?.cover_art_sizes) {
-          imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+          imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
         }
       }
     } else if (
@@ -88,7 +88,7 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
         if (playlist.playlist_image_sizes_multihash) {
           imageUrl = formatImageUrl(
             playlist.playlist_image_sizes_multihash,
-            150
+            1000
           )
         }
       }
@@ -112,7 +112,7 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
           entityType = 'contest'
           entityName = track.title
           if (track.cover_art_sizes) {
-            imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+            imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
           }
         }
       }

--- a/apps/notifications/src/processNotifications/mappers/commentReaction.ts
+++ b/apps/notifications/src/processNotifications/mappers/commentReaction.ts
@@ -64,7 +64,7 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
         entityType = 'track'
         entityName = title
         if (track?.cover_art_sizes) {
-          imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+          imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
         }
       }
     } else if (
@@ -88,7 +88,7 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
         if (playlist.playlist_image_sizes_multihash) {
           imageUrl = formatImageUrl(
             playlist.playlist_image_sizes_multihash,
-            150
+            1000
           )
         }
       }
@@ -112,7 +112,7 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
           entityType = 'contest'
           entityName = track.title
           if (track.cover_art_sizes) {
-            imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+            imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
           }
         }
       }

--- a/apps/notifications/src/processNotifications/mappers/commentThread.ts
+++ b/apps/notifications/src/processNotifications/mappers/commentThread.ts
@@ -64,7 +64,7 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
         entityType = 'track'
         entityName = title
         if (track?.cover_art_sizes) {
-          imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+          imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
         }
       }
     } else if (
@@ -88,7 +88,7 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
         if (playlist.playlist_image_sizes_multihash) {
           imageUrl = formatImageUrl(
             playlist.playlist_image_sizes_multihash,
-            150
+            1000
           )
         }
       }
@@ -112,7 +112,7 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
           entityType = 'contest'
           entityName = track.title
           if (track.cover_art_sizes) {
-            imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+            imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
           }
         }
       }

--- a/apps/notifications/src/processNotifications/mappers/cosign.ts
+++ b/apps/notifications/src/processNotifications/mappers/cosign.ts
@@ -94,11 +94,11 @@ export class CosignRemix extends BaseNotification<CosignRemixNotificationRow> {
     const title = 'New Track Co-Sign! 🔥'
     const body = `${parentTrackUserName} Co-Signed your Remix of ${remixTrackTitle}`
 
-    // Get track's cover art URL for rich notification (150x150 size)
+    // Get track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const track = tracks[this.trackId]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     await sendBrowserNotification(

--- a/apps/notifications/src/processNotifications/mappers/create.ts
+++ b/apps/notifications/src/processNotifications/mappers/create.ts
@@ -99,7 +99,7 @@ export class Create extends BaseNotification<CreateNotificationRow> {
 
       // Generate image URL for track cover art
       if (track?.cover_art_sizes) {
-        imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+        imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
       }
     }
 
@@ -119,7 +119,7 @@ export class Create extends BaseNotification<CreateNotificationRow> {
 
       // Generate image URL for playlist/album artwork
       if (playlist?.playlist_image_sizes_multihash) {
-        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
       }
     }
 

--- a/apps/notifications/src/processNotifications/mappers/fanClubTextPost.ts
+++ b/apps/notifications/src/processNotifications/mappers/fanClubTextPost.ts
@@ -78,7 +78,7 @@ export class FanClubTextPost extends BaseNotification<FanClubTextPostRow> {
     if (userMap[entityUserId]?.profile_picture_sizes) {
       imageUrl = formatImageUrl(
         userMap[entityUserId].profile_picture_sizes!,
-        150
+        1000
       )
     }
 

--- a/apps/notifications/src/processNotifications/mappers/fanRemixContestEnded.ts
+++ b/apps/notifications/src/processNotifications/mappers/fanRemixContestEnded.ts
@@ -42,7 +42,7 @@ export class FanRemixContestEnded extends BaseNotification<FanRemixContestEndedR
       .whereIn('user_id', [this.notification.data.entity_user_id])
     const artistName = res[0]?.name ?? ''
 
-    // Fetch track's cover art URL for rich notification (150x150 size)
+    // Fetch track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const trackRes: Array<{
       track_id: number
@@ -55,7 +55,7 @@ export class FanRemixContestEnded extends BaseNotification<FanRemixContestEndedR
       .whereIn('track_id', [this.notification.data.entity_id])
     const track = trackRes[0]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/fanRemixContestEndingSoon.ts
+++ b/apps/notifications/src/processNotifications/mappers/fanRemixContestEndingSoon.ts
@@ -42,7 +42,7 @@ export class FanRemixContestEndingSoon extends BaseNotification<FanRemixContestE
       .whereIn('user_id', [this.notification.data.entity_user_id])
     const artistName = res[0]?.name ?? ''
 
-    // Fetch track's cover art URL for rich notification (150x150 size)
+    // Fetch track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const trackRes: Array<{
       track_id: number
@@ -55,7 +55,7 @@ export class FanRemixContestEndingSoon extends BaseNotification<FanRemixContestE
       .whereIn('track_id', [this.notification.data.entity_id])
     const track = trackRes[0]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/fanRemixContestStarted.ts
+++ b/apps/notifications/src/processNotifications/mappers/fanRemixContestStarted.ts
@@ -42,7 +42,7 @@ export class FanRemixContestStarted extends BaseNotification<FanRemixContestStar
       .whereIn('user_id', [this.notification.data.entity_user_id])
     const artistName = artistRes[0]?.name ?? ''
 
-    // Fetch track name and cover art URL for rich notification (150x150 size)
+    // Fetch track name and cover art URL for rich notification (1000x1000 size)
     const trackRes: Array<{
       track_id: number
       title: string
@@ -57,7 +57,7 @@ export class FanRemixContestStarted extends BaseNotification<FanRemixContestStar
 
     let imageUrl: string | undefined
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/fanRemixContestSubmission.ts
+++ b/apps/notifications/src/processNotifications/mappers/fanRemixContestSubmission.ts
@@ -62,9 +62,9 @@ export class FanRemixContestSubmission extends BaseNotification<FanRemixContestS
 
     let imageUrl: string | undefined
     if (submission?.cover_art_sizes) {
-      imageUrl = formatImageUrl(submission.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(submission.cover_art_sizes, 1000)
     } else if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/fanRemixContestWinnersSelected.ts
+++ b/apps/notifications/src/processNotifications/mappers/fanRemixContestWinnersSelected.ts
@@ -45,7 +45,7 @@ export class FanRemixContestWinnersSelected extends BaseNotification<FanRemixCon
       .whereIn('user_id', [this.notification.data.entity_user_id])
     const artistName = res[0]?.name ?? ''
 
-    // Fetch track's cover art URL for rich notification (150x150 size)
+    // Fetch track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const trackRes: Array<{
       track_id: number
@@ -58,7 +58,7 @@ export class FanRemixContestWinnersSelected extends BaseNotification<FanRemixCon
       .whereIn('track_id', [this.notification.data.entity_id])
     const track = trackRes[0]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/milestone.ts
+++ b/apps/notifications/src/processNotifications/mappers/milestone.ts
@@ -129,10 +129,10 @@ export class Milestone extends BaseNotification<MilestoneRow> {
       }, {} as Record<number, { title: string; cover_art_sizes?: string | null }>)
 
       entityName = tracks[id]?.title
-      // Get track's cover art URL for rich notification (150x150 size)
+      // Get track's cover art URL for rich notification (1000x1000 size)
       const track = tracks[id]
       if (track?.cover_art_sizes) {
-        imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+        imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
       }
     } else if (
       this.type === MilestoneType.PLAYLIST_REPOST_COUNT ||
@@ -166,9 +166,9 @@ export class Milestone extends BaseNotification<MilestoneRow> {
       const playlist = playlists[id]
       entityName = playlist?.playlist_name
       isAlbum = playlist?.is_album
-      // Get playlist's image URL for rich notification (150x150 size)
+      // Get playlist's image URL for rich notification (1000x1000 size)
       if (playlist?.playlist_image_sizes_multihash) {
-        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
       }
     }
 

--- a/apps/notifications/src/processNotifications/mappers/remix.ts
+++ b/apps/notifications/src/processNotifications/mappers/remix.ts
@@ -100,11 +100,11 @@ export class Remix extends BaseNotification<RemixNotificationRow> {
     const title = 'New Remix Of Your Track ♻️'
     const body = `New remix of your track ${parentTrackTitle}: ${remixUserName} uploaded ${remixTitle}`
 
-    // Get track's cover art URL for rich notification (150x150 size)
+    // Get track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const track = tracks[this.parentTrackId]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     if (

--- a/apps/notifications/src/processNotifications/mappers/remixContestUpdate.ts
+++ b/apps/notifications/src/processNotifications/mappers/remixContestUpdate.ts
@@ -68,9 +68,9 @@ export class RemixContestUpdate extends BaseNotification<RemixContestUpdateRow> 
 
     let imageUrl: string | undefined
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     } else if (hostRes[0]?.profile_picture_sizes) {
-      imageUrl = formatImageUrl(hostRes[0].profile_picture_sizes, 150)
+      imageUrl = formatImageUrl(hostRes[0].profile_picture_sizes, 1000)
     }
 
     const userNotificationSettings = await buildUserNotificationSettings(

--- a/apps/notifications/src/processNotifications/mappers/repost.ts
+++ b/apps/notifications/src/processNotifications/mappers/repost.ts
@@ -88,9 +88,9 @@ export class Repost extends BaseNotification<RepostNotificationRow> {
         cover_art_sizes?: string
       }
       entityName = track?.title
-      // Get track's cover art URL for rich notification (150x150 size)
+      // Get track's cover art URL for rich notification (1000x1000 size)
       if (track?.cover_art_sizes) {
-        imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+        imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
       }
     } else {
       const playlist = entities[this.repostItemId] as {
@@ -100,9 +100,9 @@ export class Repost extends BaseNotification<RepostNotificationRow> {
       }
       entityType = playlist?.is_album ? EntityType.Album : EntityType.Playlist
       entityName = playlist?.playlist_name
-      // Get playlist's image URL for rich notification (150x150 size)
+      // Get playlist's image URL for rich notification (1000x1000 size)
       if (playlist?.playlist_image_sizes_multihash) {
-        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
       }
     }
 

--- a/apps/notifications/src/processNotifications/mappers/repostOfRepost.ts
+++ b/apps/notifications/src/processNotifications/mappers/repostOfRepost.ts
@@ -103,7 +103,7 @@ export class RepostOfRepost extends BaseNotification<RepostOfRepostNotificationR
       if (tracks[this.repostOfRepostItemId]?.cover_art_sizes) {
         imageUrl = formatImageUrl(
           tracks[this.repostOfRepostItemId].cover_art_sizes!,
-          150
+          1000
         )
       }
     } else {
@@ -137,7 +137,7 @@ export class RepostOfRepost extends BaseNotification<RepostOfRepostNotificationR
 
       // Generate image URL for playlist/album artwork
       if (playlist?.playlist_image_sizes_multihash) {
-        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
       }
     }
 

--- a/apps/notifications/src/processNotifications/mappers/save.ts
+++ b/apps/notifications/src/processNotifications/mappers/save.ts
@@ -88,10 +88,10 @@ export class Save extends BaseNotification<SaveNotificationRow> {
 
       entityType = 'track'
       entityName = tracks[this.saveItemId]?.title
-      // Get track's cover art URL for rich notification (150x150 size)
+      // Get track's cover art URL for rich notification (1000x1000 size)
       const track = tracks[this.saveItemId]
       if (track?.cover_art_sizes) {
-        imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+        imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
       }
     } else {
       const res: Array<{
@@ -121,9 +121,9 @@ export class Save extends BaseNotification<SaveNotificationRow> {
       const playlist = playlists[this.saveItemId]
       entityType = playlist?.is_album ? 'album' : 'playlist'
       entityName = playlist?.playlist_name
-      // Get playlist's image URL for rich notification (150x150 size)
+      // Get playlist's image URL for rich notification (1000x1000 size)
       if (playlist?.playlist_image_sizes_multihash) {
-        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
       }
     }
 

--- a/apps/notifications/src/processNotifications/mappers/saveOfRepost.ts
+++ b/apps/notifications/src/processNotifications/mappers/saveOfRepost.ts
@@ -103,7 +103,7 @@ export class SaveOfRepost extends BaseNotification<SaveOfRepostNotificationRow> 
       if (tracks[this.saveOfRepostItemId]?.cover_art_sizes) {
         imageUrl = formatImageUrl(
           tracks[this.saveOfRepostItemId].cover_art_sizes!,
-          150
+          1000
         )
       }
     } else {
@@ -137,7 +137,7 @@ export class SaveOfRepost extends BaseNotification<SaveOfRepostNotificationRow> 
 
       // Generate image URL for playlist/album artwork
       if (playlist?.playlist_image_sizes_multihash) {
-        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 150)
+        imageUrl = formatImageUrl(playlist.playlist_image_sizes_multihash, 1000)
       }
     }
 

--- a/apps/notifications/src/processNotifications/mappers/tastemaker.ts
+++ b/apps/notifications/src/processNotifications/mappers/tastemaker.ts
@@ -106,10 +106,10 @@ export class Tastemaker extends BaseNotification<TastemakerNotificationRow> {
     const title = `You're a Tastemaker!`
     const body = `${entityName} is now trending thanks to you! Great work 🙌`
 
-    // Get track's cover art URL for rich notification (150x150 size)
+    // Get track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     await sendBrowserNotification(

--- a/apps/notifications/src/processNotifications/mappers/trendingTrack.ts
+++ b/apps/notifications/src/processNotifications/mappers/trendingTrack.ts
@@ -98,11 +98,11 @@ export class TrendingTrack extends BaseNotification<TrendingTrackNotificationRow
       this.rank
     } on Trending right now!`
 
-    // Get track's cover art URL for rich notification (150x150 size)
+    // Get track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const track = tracks[this.trackId]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     await sendBrowserNotification(

--- a/apps/notifications/src/processNotifications/mappers/trendingUnderground.ts
+++ b/apps/notifications/src/processNotifications/mappers/trendingUnderground.ts
@@ -98,11 +98,11 @@ export class TrendingUnderground extends BaseNotification<TrendingUndergroundNot
       this.rank
     } on Underground Trending right now!`
 
-    // Get track's cover art URL for rich notification (150x150 size)
+    // Get track's cover art URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     const track = tracks[this.trackId]
     if (track?.cover_art_sizes) {
-      imageUrl = formatImageUrl(track.cover_art_sizes, 150)
+      imageUrl = formatImageUrl(track.cover_art_sizes, 1000)
     }
 
     await sendBrowserNotification(

--- a/apps/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
+++ b/apps/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
@@ -124,10 +124,10 @@ export class USDCPurchaseSeller extends BaseNotification<USDCPurchaseSellerRow> 
       users[this.notificationReceiverUserId]?.profile_picture_sizes
     const price = this.totalAmount
 
-    // Get content's image URL for rich notification (150x150 size)
+    // Get content's image URL for rich notification (1000x1000 size)
     let imageUrl: string | undefined
     if (cover_art_sizes) {
-      imageUrl = formatImageUrl(cover_art_sizes, 150)
+      imageUrl = formatImageUrl(cover_art_sizes, 1000)
     }
 
     await sendBrowserNotification(


### PR DESCRIPTION
Push notifications were rendering low-res 150x150 thumbnails on mobile. Bumps the rich-notification image size to 1000x1000 across every push mapper. Email-context image fields (profilePicture, artistImage, purchaserProfileImage) intentionally left at their existing sizes.