### PR TITLE
[Contest] Render contest comment notifications safely on push + email

### DIFF
--- a/apps/notifications/src/email/notifications/components/Body.tsx
+++ b/apps/notifications/src/email/notifications/components/Body.tsx
@@ -183,31 +183,54 @@ const snippetMap = {
   },
   ['comment'](notification) {
     const [user] = notification.users
-    return `${
-      user.name
-    } commented on your ${notification.entity.type.toLowerCase()} ${
-      notification.entity.name
+    // entity.type is 'Track' | 'Album' | 'Playlist' | 'Event'; for events
+    // surface "contest" instead of "event" and tolerate a missing entity row.
+    const rawEntityType =
+      notification.entity?.type === 'Event'
+        ? 'contest'
+        : notification.entity?.type?.toLowerCase() ?? 'post'
+    const entityName = notification.entity?.name ?? ''
+    return `${user.name} commented on your ${rawEntityType}${
+      entityName ? ` ${entityName}` : ''
     }`
   },
   ['comment_thread'](notification) {
     const [user] = notification.users
-    return `${user.name} replied to your comment on ${
+    const possessor =
       notification.entityUser.user_id === notification.receiverUserId
         ? 'your'
         : notification.entityUser.user_id === user.user_id
         ? 'their'
         : `${notification.entityUser.name}'s`
-    } ${notification.entity.type.toLowerCase()} ${notification.entity.name}`
+    const rawEntityType =
+      notification.entity?.type === 'Event'
+        ? 'contest'
+        : notification.entity?.type?.toLowerCase() ?? 'post'
+    const entityName = notification.entity?.name ?? ''
+    return `${
+      user.name
+    } replied to your comment on ${possessor} ${rawEntityType}${
+      entityName ? ` ${entityName}` : ''
+    }`
   },
   ['comment_mention'](notification) {
     const [user] = notification.users
-    return `${user.name} tagged you in a comment on ${
+    const possessor =
       notification.entityUser.user_id === notification.receiverUserId
         ? 'your'
         : notification.entityUser.user_id === user.user_id
         ? 'their'
         : `${notification.entityUser.name}'s`
-    } ${notification.entity.type.toLowerCase()} ${notification.entity.name}`
+    const rawEntityType =
+      notification.entity?.type === 'Event'
+        ? 'contest'
+        : notification.entity?.type?.toLowerCase() ?? 'post'
+    const entityName = notification.entity?.name ?? ''
+    return `${
+      user.name
+    } tagged you in a comment on ${possessor} ${rawEntityType}${
+      entityName ? ` ${entityName}` : ''
+    }`
   },
   ['comment_reaction'](notification) {
     const [user] = notification.users

--- a/apps/notifications/src/email/notifications/components/Body.tsx
+++ b/apps/notifications/src/email/notifications/components/Body.tsx
@@ -211,13 +211,22 @@ const snippetMap = {
   },
   ['comment_reaction'](notification) {
     const [user] = notification.users
-    return `${user.name} liked your comment on ${
+    const possessor =
       notification.entityUser.user_id === notification.receiverUserId
         ? 'your'
         : notification.entityUser.user_id === user.user_id
         ? 'their'
         : `${notification.entityUser.name}'s`
-    } ${notification.entity.type.toLowerCase()} ${notification.entity.name}`
+    // entity.type is 'Track' | 'Album' | 'Playlist' | 'Event'; for events
+    // surface "contest" instead of "event" and tolerate a missing entity row.
+    const rawEntityType =
+      notification.entity?.type === 'Event'
+        ? 'contest'
+        : notification.entity?.type?.toLowerCase() ?? 'post'
+    const entityName = notification.entity?.name ?? ''
+    return `${user.name} liked your comment on ${possessor} ${rawEntityType}${
+      entityName ? ` ${entityName}` : ''
+    }`
   }
 }
 

--- a/apps/notifications/src/processNotifications/mappers/comment.ts
+++ b/apps/notifications/src/processNotifications/mappers/comment.ts
@@ -70,8 +70,14 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
     }
 
     const commenterUserName = users[this.commenterUserId]?.name
-    let entityType: string | undefined
-    let entityName: string | undefined
+    // Default so a missing entity row never produces "commented on your
+    // undefined undefined" — the notification still reads cleanly even when
+    // the track / playlist / event row can't be resolved (e.g. deleted).
+    let entityType: string =
+      this.entityType === EntityType.Event
+        ? 'contest'
+        : (this.entityType?.toLowerCase() ?? 'post')
+    let entityName: string = ''
     let imageUrl: string | undefined
     let tracks: Record<
       number,
@@ -178,7 +184,9 @@ export class Comment extends BaseNotification<CommentNotificationRow> {
     )
 
     const title = 'New Comment'
-    const body = `${commenterUserName} commented on your ${entityType?.toLowerCase()} ${entityName}`
+    const body = `${commenterUserName} commented on your ${entityType.toLowerCase()}${
+      entityName ? ` ${entityName}` : ''
+    }`
 
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(

--- a/apps/notifications/src/processNotifications/mappers/commentMention.ts
+++ b/apps/notifications/src/processNotifications/mappers/commentMention.ts
@@ -48,8 +48,15 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
     isLiveEmailEnabled: boolean
     isBrowserPushEnabled: boolean
   }) {
-    let entityType: string
-    let entityName: string
+    // Default so a missing entity row never produces "tagged you in a
+    // comment on their undefined undefined" — the notification still reads
+    // cleanly even when the track / playlist / event row can't be resolved
+    // (e.g. deleted). Mirrors comment.ts and commentReaction.ts.
+    let entityType: string =
+      this.entityType === EntityType.Event
+        ? 'contest'
+        : this.entityType?.toLowerCase() ?? 'post'
+    let entityName = ''
     let imageUrl: string | undefined
 
     if (this.entityType === EntityType.Track) {
@@ -145,15 +152,19 @@ export class CommentMention extends BaseNotification<CommentMentionNotificationR
     )
 
     const title = 'New Mention'
-    const body = `${
-      users[this.commenterUserId]?.name
-    } tagged you in a comment on ${
+    const possessor =
       this.entityUserId === this.receiverUserId
         ? 'your'
         : this.entityUserId === this.commenterUserId
         ? 'their'
         : `${users[this.entityUserId]?.name}'s`
-    } ${entityType?.toLowerCase()} ${entityName}`
+    // Trim trailing whitespace when entityName is empty (entity lookup failed)
+    // so the message ends cleanly instead of "… their contest ".
+    const body = `${
+      users[this.commenterUserId]?.name
+    } tagged you in a comment on ${possessor} ${entityType.toLowerCase()}${
+      entityName ? ` ${entityName}` : ''
+    }`
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(
         this.receiverUserId,

--- a/apps/notifications/src/processNotifications/mappers/commentReaction.ts
+++ b/apps/notifications/src/processNotifications/mappers/commentReaction.ts
@@ -48,8 +48,14 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
     isLiveEmailEnabled: boolean
     isBrowserPushEnabled: boolean
   }) {
-    let entityType: string
-    let entityName: string
+    // Default to safe values so a missing track / event lookup never renders
+    // "liked your comment on their undefined undefined" — the notification
+    // body still reads cleanly when the entity row can't be resolved.
+    let entityType: string =
+      this.entityType === EntityType.Event
+        ? 'contest'
+        : (this.entityType?.toLowerCase() ?? 'post')
+    let entityName: string = ''
     let imageUrl: string | undefined
 
     if (this.entityType === EntityType.Track) {
@@ -145,13 +151,19 @@ export class CommentReaction extends BaseNotification<CommentReactionNotificatio
     )
 
     const title = 'New Reaction'
-    const body = `${users[this.reacterUserId]?.name} liked your comment on ${
+    const possessor =
       this.entityUserId === this.receiverUserId
         ? 'your'
         : this.entityUserId === this.reacterUserId
         ? 'their'
         : `${users[this.entityUserId]?.name}'s`
-    } ${entityType?.toLowerCase()} ${entityName}`
+    // Trim trailing whitespace when entityName is empty (entity lookup failed)
+    // so the message ends cleanly instead of "… their contest ".
+    const body = `${
+      users[this.reacterUserId]?.name
+    } liked your comment on ${possessor} ${entityType.toLowerCase()}${
+      entityName ? ` ${entityName}` : ''
+    }`
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(
         this.receiverUserId,

--- a/apps/notifications/src/processNotifications/mappers/commentThread.ts
+++ b/apps/notifications/src/processNotifications/mappers/commentThread.ts
@@ -48,8 +48,15 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
     isLiveEmailEnabled: boolean
     isBrowserPushEnabled: boolean
   }) {
-    let entityType: string
-    let entityName: string
+    // Default so a missing entity row never produces "replied to your comment
+    // on their undefined undefined" — the notification still reads cleanly
+    // even when the track / playlist / event row can't be resolved (e.g.
+    // deleted). Mirrors comment.ts and commentReaction.ts.
+    let entityType: string =
+      this.entityType === EntityType.Event
+        ? 'contest'
+        : this.entityType?.toLowerCase() ?? 'post'
+    let entityName = ''
     let imageUrl: string | undefined
 
     if (this.entityType === EntityType.Track) {
@@ -145,15 +152,19 @@ export class CommentThread extends BaseNotification<CommentThreadNotificationRow
     )
 
     const title = 'New Reply'
-    const body = `${
-      users[this.commenterUserId]?.name
-    } replied to your comment on ${
+    const possessor =
       this.entityUserId === this.receiverUserId
         ? 'your'
         : this.entityUserId === this.commenterUserId
         ? 'their'
         : `${users[this.entityUserId]?.name}'s`
-    } ${entityType?.toLowerCase()} ${entityName}`
+    // Trim trailing whitespace when entityName is empty (entity lookup failed)
+    // so the message ends cleanly instead of "… their contest ".
+    const body = `${
+      users[this.commenterUserId]?.name
+    } replied to your comment on ${possessor} ${entityType.toLowerCase()}${
+      entityName ? ` ${entityName}` : ''
+    }`
     if (
       userNotificationSettings.isNotificationTypeBrowserEnabled(
         this.receiverUserId,


### PR DESCRIPTION
## Summary

Push and email bodies for `comment` / `comment_reaction` / `comment_thread` / `comment_mention` notifications on a contest event were rendering literals like \"X commented on your undefined undefined\" or \"X liked your comment on their undefined\" whenever the entity row couldn't be resolved (deleted event, race after entity unfurl, event row not present at processing time).

Two-step fix across the notification mapper layer:

1. **`comment` + `comment_reaction`** — default `entityType` to \"contest\" for events (and to a lower-case form of the entity type otherwise), default `entityName` to `\"\"` so a missing entity row no longer leaks the literal string `undefined`, and trim the trailing space when the entity name is empty so the message ends cleanly at \"their contest\" instead of \"their contest \".
2. **`comment_thread` (replies) + `comment_mention` (@mentions) + email Body.tsx snippetMap** — extend the same safe defaults to the remaining surfaces. These paths still rendered \"… on their undefined undefined\" because the previous fix only covered `comment` and `comment_reaction`.

## Files touched

- `apps/notifications/src/processNotifications/mappers/comment.ts`
- `apps/notifications/src/processNotifications/mappers/commentReaction.ts`
- `apps/notifications/src/processNotifications/mappers/commentThread.ts`
- `apps/notifications/src/processNotifications/mappers/commentMention.ts`
- `apps/notifications/src/email/notifications/components/Body.tsx`

## Commits

- `2f01992` Notifications: render contest comment / reaction bodies safely
- `7cc9cf2` Notifications: extend safe entity rendering to mention + reply bodies

## Test plan

- [ ] Receive a contest comment push notification — body reads \"X commented on your contest <name>\" (or \"… on your contest\" when the entity row is missing), never \"undefined\"
- [ ] Receive a contest comment-reaction push — \"X liked your comment on their contest <name>\"
- [ ] Receive a contest reply (comment_thread) push — same rendering
- [ ] Receive a contest @mention push — same rendering
- [ ] Email digest renders the same bodies cleanly via Body.tsx snippetMap

🤖 Generated with [Claude Code](https://claude.com/claude-code)