### PR TITLE
notifications: port welcome email from identity-service

### DIFF
--- a/apps/notifications/src/email/notifications/preRendered/welcome.ts
+++ b/apps/notifications/src/email/notifications/preRendered/welcome.ts
@@ -1,0 +1,1289 @@
+// Welcome email template — ported from
+// packages/identity-service/src/notifications/emails/welcome.js in the apps repo.
+// Body is unchanged; only the export shape is converted to TS so the
+// pedalboard transactional-email plumbing can call it directly.
+
+export type WelcomeFeaturedTrack = {
+  permalink?: string
+  title?: string
+  artwork?: { '480x480'?: string } | null
+  user?: { name?: string } | null
+}
+
+export type GetWelcomeEmailArgs = {
+  name: string
+  copyrightYear: string
+  /**
+   * Top trending tracks rendered in the "Featured on Audius" section.
+   * Optional: the template is null-safe per slot, so an empty list
+   * just hides the artwork without breaking the layout.
+   */
+  featuredContent?: WelcomeFeaturedTrack[]
+}
+
+export const getWelcomeEmail = ({
+  name,
+  copyrightYear,
+  featuredContent
+}: GetWelcomeEmailArgs): string => {
+  return `<!doctype html>
+  <html lang="en" xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+  
+  <head>
+  <meta charset="utf-8" />
+  <meta content="width=device-width" name="viewport" />
+  <meta content="IE=edge" http-equiv="X-UA-Compatible" />
+  <meta name="x-apple-disable-message-reformatting" />
+  <meta content="telephone=no,address=no,email=no,date=no,url=no" name="format-detection" />
+  <title>Welcome to Audius! 👋</title>
+  <!--[if mso]>
+              <style>
+                  * {
+                      font-family: sans-serif !important;
+                  }
+              </style>
+          <![endif]-->
+  <!--[if !mso]><!-->
+  <!-- <![endif]-->
+  <link href="https://fonts.googleapis.com/css?family=Inter:600" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:400" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:900" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Inter:500" rel="stylesheet" type="text/css">
+  <style>
+  html {
+      margin: 0 !important;
+      padding: 0 !important;
+  }
+  
+  * {
+      -ms-text-size-adjust: 100%;
+      -webkit-text-size-adjust: 100%;
+  }
+  td {
+      vertical-align: top;
+      mso-table-lspace: 0pt !important;
+      mso-table-rspace: 0pt !important;
+  }
+  a {
+      text-decoration: none;
+  }
+  img {
+      -ms-interpolation-mode:bicubic;
+  }
+  @media only screen and (min-device-width: 320px) and (max-device-width: 374px) {
+      u ~ div .email-container {
+          min-width: 320px !important;
+      }
+  }
+  @media only screen and (min-device-width: 375px) and (max-device-width: 413px) {
+      u ~ div .email-container {
+          min-width: 375px !important;
+      }
+  }
+  @media only screen and (min-device-width: 414px) {
+      u ~ div .email-container {
+          min-width: 414px !important;
+      }
+  }
+  
+  </style>
+  <!--[if gte mso 9]>
+          <xml>
+              <o:OfficeDocumentSettings>
+                  <o:AllowPNG/>
+                  <o:PixelsPerInch>96</o:PixelsPerInch>
+              </o:OfficeDocumentSettings>
+          </xml>
+          <![endif]-->
+  <style>
+  @media only screen and (max-device-width: 599px), only screen and (max-width: 599px) {
+  
+      .eh {
+          height:auto !important;
+      }
+      .desktop {
+          display: none !important;
+          height: 0 !important;
+          margin: 0 !important;
+          max-height: 0 !important;
+          overflow: hidden !important;
+          padding: 0 !important;
+          visibility: hidden !important;
+          width: 0 !important;
+      }
+      .mobile {
+          display: block !important;
+          width: auto !important;
+          height: auto !important;
+          float: none !important;
+      }
+      .email-container {
+          width: 100% !important;
+          margin: auto !important;
+      }
+      .stack-column,
+      .stack-column-center {
+          display: block !important;
+          width: 100% !important;
+          max-width: 100% !important;
+          direction: ltr !important;
+      }
+      .wid-auto {
+          width:auto !important;
+      }
+  
+      .table-w-full-mobile {
+          width: 100%;
+      }
+  
+      
+      
+  
+      .mobile-center {
+          text-align: center;
+      }
+  
+      .mobile-center > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+  
+      .mobile-left {
+          text-align: left;
+      }
+  
+      .mobile-left > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+  
+      .mobile-right {
+          text-align: right;
+      }
+  
+      .mobile-right > table {
+          display: inline-block;
+          vertical-align: inherit;
+      }
+  
+  }
+  
+  </style>
+  </head>
+  
+  <body width="100%" style="background-color:#eeedef;margin:0;padding:0!important;mso-line-height-rule:exactly;">
+  <div style="background-color:#eeedef">
+  <!--[if gte mso 9]>
+                                              <v:background xmlns:v="urn:schemas-microsoft-com:vml" fill="t">
+                                              <v:fill type="tile" color="#eeedef"/>
+                                              </v:background>
+                                              <![endif]-->
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+  <td valign="top" align="center">
+  <div id="preview_text" style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: sans-serif;"> Audius is more than just a music platform—it's a marketplace where artists can sell their songs and stems directly to fans </div>
+  <!-- Visually Hidden Preheader Text : END -->
+  <!-- Preview Text Spacing Hack : BEGIN -->
+  <div style="display: none; font-size: 1px; line-height: 1px; max-height: 0px; max-width: 0px; opacity: 0; overflow: hidden; mso-hide: all; font-family: sans-serif;"> &zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp;&zwnj;&nbsp; </div>
+  <table bgcolor="#ffffff" style="margin:0 auto;" align="center" id="brick_container" cellspacing="0" cellpadding="0" border="0" width="600" class="email-container">
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="600" style="background-color:#ffffff;  " bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="584" style="vertical-align: middle; background-color:#ffffff;  border-width: 0px 0px 1px 0px; border-color:#eeedef; border-style:solid; padding-left:8px; padding-right:8px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="224"><img src="https://download.audius.co/welcome-email/Uz1cn9ptGz0zHqqougR9jczjWIzEi2.jpeg" width="224" border="0" style="max-width:224px; width: 100%;
+           height: auto; display: block;"></td>
+  <td></td>
+  <td style="vertical-align: middle;" width="120">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="112" align="center" style="vertical-align: middle; border-radius:2px;  padding-left:4px; padding-right:4px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="right" style="vertical-align: middle; height:32px; border-radius:2px;  padding-left:4px; padding-right:4px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://twitter.com/audius"><img src="https://download.audius.co/welcome-email/wD4gGCdHNNWPmqcVaVODlWgVaMF632.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://www.instagram.com/audius/"><img src="https://download.audius.co/welcome-email/34rb0mOMe83vV5t7IykMNFM0HPwsSP.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://tiktok.com/@audius"><img src="https://download.audius.co/welcome-email/ADJ1TJJagsFjXki8AONs98yXUYDoUR.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="600">
+  <table cellpadding="0" cellspacing="0" bgcolor="#ffffff" height="16" width="100%" style="line-height:16px;height:16px!important;background-color:#ffffff;  border-collapse:separate !important;margin:0 auto;text-align:center;">
+  <tr>
+  <td> </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552" style="vertical-align: middle; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:24px;text-align:left;"><span style="color:#7e1bcc;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Welcome to Audius!</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:36px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:27px;letter-spacing:-0.02em;line-height:36px;text-align:left;">Hey ${name} 👋</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Welcome aboard!<br><br>Audius is more than just a music platform—it's a marketplace where artists can sell their songs and stems directly to fans. Our vibrant global community of creators thrives on remixing and collaboration. Discover new music, connect with artists, and be part of the creative process. Here, fans and artists unite to create, share, and vibe with the music.</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="600">
+  <table cellpadding="0" cellspacing="0" bgcolor="#ffffff" height="24" width="100%" style="line-height:24px;height:24px!important;background-color:#ffffff;  border-collapse:separate !important;margin:0 auto;text-align:center;">
+  <tr>
+  <td> </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552" align="center" style="background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td width="100%" class="npvFzttiQ9blCqk91jVlzlepHedvRo invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/welcome-email/npvFzttiQ9blCqk91jVlzlepHedvRo.png">
+  <!--[if gte mso 9]>
+                  <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:328px;"
+                  src="https://download.audius.co/welcome-email/npvFzttiQ9blCqk91jVlzlepHedvRo.png"
+                  />
+                  <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 552px; height:328px;">
+                  <v:fill opacity="0%" color="#000" />
+                  <v:textbox inset="0,0,0,0">
+                  <![endif]-->
+  <div>
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:24px;text-align:left;"><span style="color:#7e1bcc;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Free & Unlimited</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:48px;text-align:left;"><span style="color:#2f2e37;font-weight:900;font-family:Inter,Arial,sans-serif;font-size:43px;letter-spacing:-0.02em;line-height:48px;text-align:left;">Create & Share</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:24px;text-align:left;"><span style="color:#2f2e37;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Unlimited lossless uploads and high-quality music streaming for free! Download stems to create unique remixes, and share curated playlists with your friends.</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td>
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://audius.co/upload"><img src="https://download.audius.co/welcome-email/WH3RZHAdlMWSXFdSp7B6LAeIqxV0ID.png" width="160" border="0" style="min-width:160px; width:160px;
+          border-radius:8px; height: auto; display: block;"></a></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
+  </tr>
+  </table>
+  </div>
+  <!--[if gte mso 9]>
+                  </v:textbox>
+                  </v:fill>
+                  </v:rect>
+                  </v:image>
+                  <![endif]-->
+  </td>
+  </tr>
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552" style="background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td width="100%" align="center">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td width="100%">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td width="40"><img src="https://download.audius.co/welcome-email/h9gRVVDkGx5CCmguwNaHygJVSZ3A0N.png" width="40" border="0" style="min-width:40px; width:40px;
+          border-radius:32px; height: auto; display: block;"></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td>
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">Earn On Your Terms</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">You set the price, and earn bonus $AUDIO for every sale.</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="100%">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td width="40"><img src="https://download.audius.co/welcome-email/eVzGmzbcF4QIPEWugZUklMtzhckXC8.png" width="40" border="0" style="min-width:40px; width:40px;
+          border-radius:32px; height: auto; display: block;"></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td>
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">Grow Your Fanbase</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Unlimited uploads, metrics, dashboards, and more - All free forever, no strings attached.</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="100%">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td width="40"><img src="https://download.audius.co/welcome-email/IguAppBacUFH6iTvxGh84ZGTYoNE19.png" width="40" border="0" style="min-width:40px; width:40px;
+          border-radius:32px; height: auto; display: block;"></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td>
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">Free Unlimited Uploads & No Ads</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Free to use, with no limitations on uploads and a completely ad-free experience.</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" style="vertical-align: middle; height:48px; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="552">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552">
+  <table cellpadding="0" cellspacing="0" height="1" width="100%" style="line-height:1px;height:1px!important; border:1px solid #eeedef; border-collapse:separate !important;margin:0 auto;text-align:center;">
+  <tr>
+  <td> </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552" style="vertical-align: middle; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:36px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:27px;letter-spacing:-0.02em;line-height:36px;text-align:left;">Featured Content</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;">
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">Some of our favorite things on Audius right now</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552" style="background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td width="552" align="center">
+  <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center" width="30.43%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td width="168" align="center"><a href="https://audius.co${featuredContent?.[0]?.permalink}"><img src=${featuredContent?.[0]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
+          border-radius:8px; height: auto; display: block;"></td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td width="100%" align="center" style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${featuredContent?.[0]?.title}</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${featuredContent?.[0]?.user?.name}</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  <td class="stack-column-center" height="24" style="width:24px; min-width:24px; height:24px; min-height:24px;" width="24"></td>
+  <td align="center" width="30.43%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td width="168" align="center"><a href="https://audius.co${featuredContent?.[1]?.permalink}"><img src=${featuredContent?.[1]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
+          border-radius:8px; height: auto; display: block;"></a></td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td width="100%" align="center" style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${featuredContent?.[1]?.title}</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${featuredContent?.[1]?.user?.name}</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  <td class="stack-column-center" height="24" style="width:24px; min-width:24px; height:24px; min-height:24px;" width="24"></td>
+  <td align="center" width="30.43%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td width="168" align="center"><a href="https://audius.co${featuredContent?.[2]?.permalink}"><img src=${featuredContent?.[2]?.artwork?.['480x480']} width="168" border="0" style="width: 100%;
+          border-radius:8px; height: auto; display: block;"></td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td width="100%" align="center" style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:16px;letter-spacing:-0.02em;line-height:24px;text-align:left;">${featuredContent?.[2]?.title}</span></div>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td>
+  <div style="line-height:24px;text-align:left;"><span style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:16px;line-height:24px;text-align:left;">${featuredContent?.[2]?.user?.name}</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552" align="center" style="vertical-align: middle; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" width="420">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="420" align="center">
+  <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td class="stack-column-center" align="center">
+  <div>
+  <!--[if mso]>
+                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://audius.co/trending?timeRange=month" style="height:48px;v-text-anchor:middle;width:420px;" fillcolor="#ffffff" strokecolor="#a5a4ad" strokeweight="1pt" arcsize="17%">
+                          <w:anchorlock/>
+                          <center style="white-space:nowrap;display:inline-block;text-align:center;color:#2f2e37;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;">More Recommendations</center>
+                          </v:roundrect>
+                      <![endif]-->
+  <a target="_blank" href="https://audius.co/trending?timeRange=month" style="white-space:nowrap;background-color:#ffffff;border-radius:8px; border:1px solid #a5a4ad;display:inline-block;text-align:center;color:#2f2e37;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;line-height:48px;width:100%; -webkit-text-size-adjust:none;mso-hide:all;">More Recommendations</a>
+  </div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" style="vertical-align: middle; height:48px; background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="552">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552">
+  <table cellpadding="0" cellspacing="0" height="1" width="100%" style="line-height:1px;height:1px!important; border:1px solid #eeedef; border-collapse:separate !important;margin:0 auto;text-align:center;">
+  <tr>
+  <td> </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" align="center" style="background-color:#ffffff;   padding-left:24px; padding-right:24px;" bgcolor="#ffffff">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td width="100%" align="center" class="Sj77PTPNDM0PwCXKJ8XbtrzPkFy81V invert-bg" style="vertical-align: middle; background-repeat:no-repeat !important; background-position: center center !important; background-size: cover !important;border-radius:12px; border-collapse:separate !important; padding-left:24px; padding-right:24px;" background="https://download.audius.co/welcome-email/Sj77PTPNDM0PwCXKJ8XbtrzPkFy81V.png">
+  <!--[if gte mso 9]>
+                  <v:image xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block; width: 552px; height:182px;"
+                  src="https://download.audius.co/welcome-email/Sj77PTPNDM0PwCXKJ8XbtrzPkFy81V.png"
+                  />
+                  <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style=" border: 0;display: inline-block;position: absolute; width: 552px; height:182px;">
+                  <v:fill opacity="0%" color="#000" />
+                  <v:textbox inset="0,0,0,0">
+                  <![endif]-->
+  <div>
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="36" style="height:36px; min-height:36px; line-height:36px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" align="center" style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:36px;text-align:center;"><span style="color:#2f2e37;font-weight:700;font-family:Inter,Arial,sans-serif;font-size:27px;letter-spacing:-0.02em;line-height:36px;text-align:center;">Download The App!</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" align="center">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td width="504" align="center" style="vertical-align: middle;  ">
+  <table class="table-w-full-mobile" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://apps.apple.com/us/app/audius-music/id1491270519"><img src="https://download.audius.co/welcome-email/k4TOOjAR7VuPP0nueaLRqEgGVORdm0.png" width="142" border="0" style="min-width:142px; width:142px;
+           height: auto; display: block;"></a></td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://play.google.com/store/apps/details?id=co.audius.app&hl=en_US&gl=US"><img src="https://download.audius.co/welcome-email/8qZWjB40ILUL2qHxBLKct5TmRFr8ii.png" width="166" border="0" style="min-width:166px; width:166px;
+           height: auto; display: block;"></a></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="36" style="height:36px; min-height:36px; line-height:36px;"></td>
+  </tr>
+  </table>
+  </div>
+  <!--[if gte mso 9]>
+                  </v:textbox>
+                  </v:fill>
+                  </v:rect>
+                  </v:image>
+                  <![endif]-->
+  </td>
+  </tr>
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td width="600">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="552" align="center" style="vertical-align: middle; background-color:#fbfbfb;  border-width: 1px 0px 0px 0px; border-color:#eeedef; border-style:solid; padding-left:24px; padding-right:24px;" bgcolor="#fbfbfb">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" align="center" style="vertical-align: middle; border-radius:8px; ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" style="  padding-left:12px; padding-right:12px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  <tr>
+  <td width="528" align="center" style="vertical-align: middle;  ">
+  <table class="table-w-full-mobile" width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;" class="stack-column-center" align="center"><a target="_blank" href="https://www.audius.co"><img src="https://download.audius.co/welcome-email/cBesqDAb5hRDxoQksHZUXPMGv5h9bm.png" width="168" border="0" style="min-width:168px; width:168px;
+          border-radius:2px; height: auto; display: block;"></a></td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
+  <td class="stack-column-center" style="width:168px;"></td>
+  <td class="stack-column-center" height="12" style="width:12px; min-width:12px; height:12px; min-height:12px;" width="12"></td>
+  <td style="vertical-align: middle;" align="center" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:4px; padding-right:4px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="right" style="vertical-align: middle; height:32px; border-radius:2px;  padding-left:4px; padding-right:4px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="144">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="144" style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://twitter.com/audius"><img src="https://download.audius.co/welcome-email/spr1x1FjdDaoinJSgyafCHbJIEO2LN.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://www.instagram.com/audius/"><img src="https://download.audius.co/welcome-email/c7X1kw0ciUVlLIClmMJ5EY4aRtlGnK.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://tiktok.com/@audius"><img src="https://download.audius.co/welcome-email/11MnDiUVzMuQyikvAHjRMkEOd2Dt7c.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  <td style="width:16px; min-width:16px;" width="16"></td>
+  <td style="vertical-align: middle;"><a target="_blank" href="https://www.youtube.com/@AudiusMusic"><img src="https://download.audius.co/welcome-email/zTUTTlgXyRIkRgqgJ59JSs6QGkV2K2.png" width="24" border="0" style="min-width:24px; width:24px;
+           height: auto; display: block;"></a></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="4" style="height:4px; min-height:4px; line-height:4px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="12" style="height:12px; min-height:12px; line-height:12px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" width="528">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="528" align="center" style="vertical-align: middle;  ">
+  <table class="table-w-full-mobile" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.co"><span style="color:#a5a4ad;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Audius Music</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://help.audius.co"><span style="color:#a5a4ad;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Help & Support</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"></td>
+  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://blog.audius.co"><span style="color:#a5a4ad;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">The Blog</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://www.audius.events"><span style="color:#a5a4ad;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Events</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  <td class="stack-column-center" height="8" style="width:8px; min-width:8px; height:8px; min-height:8px;" width="8"></td>
+  <td style="vertical-align: middle;" align="center" width="32.32%" class="stack-column-center">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td align="center" style="vertical-align: middle; border-radius:2px;  padding-left:16px; padding-right:16px;">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://brand.audius.co"><span style="color:#a5a4ad;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Brand / Press</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><a target="_blank" href="https://merch.audius.co"><span style="color:#a5a4ad;font-weight:500;font-family:Inter,Arial,sans-serif;font-size:14px;line-height:14px;text-align:center;">Merch Store</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="16" style="height:16px; min-height:16px; line-height:16px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" width="100%">
+  <table width="100%" cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td width="100%" align="center" style="vertical-align: middle;  ">
+  <table width="100%" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+  <td align="center">
+  <table cellspacing="0" cellpadding="0" border="0">
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><span style="color:#a5a4ad;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">© ${copyrightYear} Audius, Inc. All Rights Reserved.</span></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="8" style="height:8px; min-height:8px; line-height:8px;"></td>
+  </tr>
+  <tr>
+  <td style="vertical-align: middle;" align="center">
+  <div style="line-height:14px;text-align:center;"><span
+    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">No
+    longer want to receive these emails? </span><a href="<%asm_group_unsubscribe_raw_url%>"><span
+    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">Unsubscribe
+  </span></a><span
+    style="color:#6a677a;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;">or</span><a href="<%asm_preferences_raw_url%>"><span
+    style="color:#7e1bcc;font-family:Inter,Arial,sans-serif;font-size:12px;line-height:14px;text-align:center;"> Manage
+    Email Preferences</span></a></div>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="24" style="height:24px; min-height:24px; line-height:24px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  <tr>
+  <td height="48" style="height:48px; min-height:48px; line-height:48px;"></td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </td>
+  </tr>
+  </table>
+  </div>
+  </body>
+  
+  </html>
+`
+}

--- a/apps/notifications/src/email/notifications/welcomeEmail.ts
+++ b/apps/notifications/src/email/notifications/welcomeEmail.ts
@@ -1,0 +1,189 @@
+import { Knex } from 'knex'
+
+import { logger } from '../../logger'
+import {
+  getWelcomeEmail,
+  type WelcomeFeaturedTrack
+} from './preRendered/welcome'
+import { sendTransactionalEmail } from './sendEmail'
+
+// Default REST endpoint to fetch trending tracks for the "Featured on
+// Audius" section. Override via DISCOVERY_PROVIDER_URL when running
+// against a custom DN. The template is null-safe per slot, so a
+// fetch failure just hides the artwork.
+const DEFAULT_DISCOVERY_PROVIDER_URL = 'https://discoveryprovider.audius.co'
+
+type IdentityUserRow = {
+  id: number
+  email: string | null
+  walletAddress: string | null
+  handle: string | null
+  isEmailDeliverable: boolean | null
+  isBlockedFromEmails: boolean | null
+}
+
+const fetchIdentityUserById = async (
+  identityDb: Knex,
+  userId: number
+): Promise<IdentityUserRow | null> => {
+  const row = await identityDb<IdentityUserRow>('Users')
+    .select(
+      'id',
+      'email',
+      'walletAddress',
+      'handle',
+      'isEmailDeliverable',
+      'isBlockedFromEmails'
+    )
+    .where({ id: userId })
+    .first()
+  return row ?? null
+}
+
+const fetchFeaturedTrendingTracks = async (): Promise<
+  WelcomeFeaturedTrack[]
+> => {
+  const baseUrl =
+    process.env.DISCOVERY_PROVIDER_URL?.replace(/\/$/, '') ||
+    DEFAULT_DISCOVERY_PROVIDER_URL
+  const url = `${baseUrl}/v1/full/tracks/trending?limit=3&offset=0&time=month`
+  try {
+    const res = await fetch(url)
+    if (!res.ok) {
+      logger.warn(
+        `welcomeEmail: trending fetch ${res.status} ${res.statusText}`
+      )
+      return []
+    }
+    const json = (await res.json()) as { data?: WelcomeFeaturedTrack[] }
+    return json?.data ?? []
+  } catch (e) {
+    logger.warn(`welcomeEmail: trending fetch failed ${(e as Error).message}`)
+    return []
+  }
+}
+
+const recordHasSignedInNativeMobile = async (
+  identityDb: Knex,
+  walletAddress: string,
+  hasSignedInNativeMobile: boolean
+) => {
+  // Same upsert identity-service did at /email/welcome — the dashboard
+  // and signup analytics rely on this flag landing in UserEvents.
+  await identityDb.raw(
+    `
+    INSERT INTO "UserEvents" ("walletAddress", "hasSignedInNativeMobile", "createdAt", "updatedAt")
+    VALUES (:walletAddress, :hasSignedInNativeMobile, now(), now())
+    ON CONFLICT ("walletAddress")
+    DO UPDATE SET "hasSignedInNativeMobile" = :hasSignedInNativeMobile;
+    `,
+    { walletAddress, hasSignedInNativeMobile }
+  )
+}
+
+export type SendWelcomeEmailArgs = {
+  identityDb: Knex
+  /** blockchainUserId of the new user (Users.id in identity DB). */
+  userId: number
+  /** Display name to greet the user with — usually the user's handle. */
+  name: string
+  /** Was this signup completed in the native mobile app? */
+  isNativeMobile?: boolean
+}
+
+export type SendWelcomeEmailResult =
+  | { sent: true }
+  | { sent: false; reason: 'no-user' | 'undeliverable' | 'blocked' | 'error' }
+
+/**
+ * Send the post-signup welcome email. Trigger semantics match what
+ * identity-service /email/welcome did before this lived here:
+ *
+ * - Skip silently when the user has `isEmailDeliverable = false`
+ *   (e.g. signed up with a Privy email we don't deliver to) or
+ *   `isBlockedFromEmails = true`.
+ * - Best-effort fetch of three trending tracks for the body — a
+ *   failed fetch hides the artwork tiles but doesn't block the email.
+ * - Mirror the SendGrid envelope identity used: from
+ *   "The Audius Team <team@audius.co>", subject "Welcome to Audius! 👋",
+ *   asm group 23583 (transactional unsubscribe group, used by other
+ *   pedalboard transactional emails).
+ * - Upsert UserEvents.hasSignedInNativeMobile so the signup-source
+ *   analytics keep working.
+ */
+export const sendWelcomeEmail = async ({
+  identityDb,
+  userId,
+  name,
+  isNativeMobile = false
+}: SendWelcomeEmailArgs): Promise<SendWelcomeEmailResult> => {
+  const user = await fetchIdentityUserById(identityDb, userId)
+  if (!user) {
+    logger.info(`welcomeEmail: no identity user for id=${userId}`)
+    return { sent: false, reason: 'no-user' }
+  }
+  if (!user.email) {
+    logger.info(`welcomeEmail: missing email for userId=${userId}`)
+    return { sent: false, reason: 'undeliverable' }
+  }
+  if (user.isEmailDeliverable === false) {
+    logger.info(
+      `welcomeEmail: undeliverable email for handle=${user.handle} (id=${userId})`
+    )
+    return { sent: false, reason: 'undeliverable' }
+  }
+  if (user.isBlockedFromEmails === true) {
+    logger.info(
+      `welcomeEmail: blocked from emails handle=${user.handle} (id=${userId})`
+    )
+    return { sent: false, reason: 'blocked' }
+  }
+
+  const featuredContent = await fetchFeaturedTrendingTracks()
+  const copyrightYear = new Date().getFullYear().toString()
+
+  const html = getWelcomeEmail({ name, copyrightYear, featuredContent })
+
+  // Route through sendTransactionalEmail so welcome inherits the global
+  // 1-in-N sample gate (`config.notificationEmailSampleDenominator`) the
+  // way claimable-reward / reward-in-cooldown do. The asm group (23583)
+  // is applied inside sendTransactionalEmail; we only override `from` so
+  // the welcome envelope reads "The Audius Team" instead of the
+  // default "Audius". A `false` return covers both an actual SendGrid
+  // failure (logged at error level) and a sample-out skip (logged at
+  // debug level) — both surface as `reason: 'error'` here, with the
+  // logs being the disambiguator.
+  const sent = await sendTransactionalEmail({
+    email: user.email,
+    html,
+    subject: 'Welcome to Audius! 👋',
+    from: 'The Audius Team <team@audius.co>'
+  })
+  if (!sent) {
+    return { sent: false, reason: 'error' }
+  }
+
+  if (user.walletAddress) {
+    try {
+      await recordHasSignedInNativeMobile(
+        identityDb,
+        user.walletAddress,
+        isNativeMobile
+      )
+    } catch (e) {
+      // Don't fail the whole call on the analytics upsert — the email
+      // already went out.
+      logger.warn(
+        `welcomeEmail: UserEvents upsert failed for wallet=${
+          user.walletAddress
+        }: ${(e as Error).message}`
+      )
+    }
+  }
+
+  logger.info(
+    { userId, handle: user.handle, isNativeMobile },
+    'welcomeEmail: sent'
+  )
+  return { sent: true }
+}

--- a/apps/notifications/src/email/notifications/welcomeEmail.ts
+++ b/apps/notifications/src/email/notifications/welcomeEmail.ts
@@ -7,6 +7,17 @@ import {
 } from './preRendered/welcome'
 import { sendTransactionalEmail } from './sendEmail'
 
+// Node 18+ exposes `fetch` as a global (apps/notifications/Dockerfile
+// pins `node:18.16-alpine`), but @types/node@17.0.29 in this workspace
+// doesn't type it yet. Declare the slice we actually use here rather
+// than pulling `lib: ["dom"]` into every file in the service.
+declare const fetch: (input: string) => Promise<{
+  ok: boolean
+  status: number
+  statusText: string
+  json: () => Promise<unknown>
+}>
+
 // Default REST endpoint to fetch trending tracks for the "Featured on
 // Audius" section. Override via DISCOVERY_PROVIDER_URL when running
 // against a custom DN. The template is null-safe per slot, so a

--- a/apps/notifications/src/server/index.ts
+++ b/apps/notifications/src/server/index.ts
@@ -5,6 +5,7 @@ import { Server as HttpServer } from 'http'
 import { router as healthCheckRouter } from './routes/healthCheck'
 import { router as memStatsRouter } from './routes/memStats'
 import { createSendAnnouncementRouter } from './routes/sendAnnouncement'
+import { createSendWelcomeEmailRouter } from './routes/sendWelcomeEmail'
 
 const DEFAULT_PORT = 6000
 
@@ -26,6 +27,10 @@ export class Server {
       this.app.use(
         '/internal/send-announcement',
         createSendAnnouncementRouter(discoveryDb)
+      )
+      this.app.use(
+        '/internal/send-welcome-email',
+        createSendWelcomeEmailRouter(identityDb)
       )
     }
 

--- a/apps/notifications/src/server/routes/sendWelcomeEmail.ts
+++ b/apps/notifications/src/server/routes/sendWelcomeEmail.ts
@@ -1,0 +1,79 @@
+import { Router, Request, Response } from 'express'
+import { Knex } from 'knex'
+
+import { logger } from '../../logger'
+import { sendWelcomeEmail } from '../../email/notifications/welcomeEmail'
+
+/**
+ * `/internal/send-welcome-email` — Bearer-secret-protected endpoint that
+ * the signup flow (or identity-service) calls right after a user is
+ * created so the post-signup email goes out from this service. Replaces
+ * the old `/email/welcome` route in identity-service.
+ *
+ * Trigger semantics: the caller is expected to invoke this on the
+ * `user create / signup` event — pedalboard doesn't currently have a
+ * notification-table or pg-notify hook for user creation (only
+ * `notification` rows), so this stays a deliberate HTTP call mirroring
+ * the existing internal-route pattern (see `sendAnnouncement.ts`).
+ *
+ * Auth: `Authorization: Bearer ${WELCOME_EMAIL_SEND_SECRET}`. If the
+ * env var isn't set the route disables itself — same pattern as
+ * `sendAnnouncement.ts`.
+ *
+ * Body: `{ userId: number, name: string, isNativeMobile?: boolean }`
+ */
+export function createSendWelcomeEmailRouter(identityDb: Knex): Router {
+  const router = Router()
+
+  router.post('/', async (req: Request, res: Response) => {
+    const secret = process.env.WELCOME_EMAIL_SEND_SECRET
+    if (!secret) {
+      res.status(503).json({
+        error:
+          'Send-welcome-email is disabled: set WELCOME_EMAIL_SEND_SECRET in env to enable.'
+      })
+      return
+    }
+    const auth = req.headers.authorization
+    if (auth !== `Bearer ${secret}`) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+
+    const { userId, name, isNativeMobile } = req.body ?? {}
+    const parsedUserId =
+      Number.isFinite(Number(userId)) && Number(userId) > 0
+        ? Number(userId)
+        : null
+    const trimmedName =
+      typeof name === 'string' && name.trim().length > 0 ? name.trim() : null
+
+    if (parsedUserId === null) {
+      res
+        .status(400)
+        .json({ error: 'userId is required and must be a positive integer' })
+      return
+    }
+    if (trimmedName === null) {
+      res.status(400).json({ error: 'name is required' })
+      return
+    }
+
+    try {
+      const result = await sendWelcomeEmail({
+        identityDb,
+        userId: parsedUserId,
+        name: trimmedName,
+        isNativeMobile: !!isNativeMobile
+      })
+      res.json(result)
+    } catch (e) {
+      logger.error(e, 'send-welcome-email failed')
+      res.status(500).json({
+        error: e instanceof Error ? e.message : 'Send welcome email failed'
+      })
+    }
+  })
+
+  return router
+}


### PR DESCRIPTION
The post-signup welcome email used to live in [apps/packages/identity-service/src/routes/welcomeEmail.js](https://github.com/AudiusProject/apps/blob/main/packages/identity-service/src/routes/welcomeEmail.js). Moving the SendGrid send + UserEvents upsert into pedalboard's notifications service so all transactional sends share one set of rendering, retry, and unsubscribe-group plumbing.

## What's added

- **`apps/notifications/src/email/notifications/preRendered/welcome.ts`** — 1:1 port of the 1264-line welcome template from identity-service. Markup unchanged; just typed and re-exported as `getWelcomeEmail`. Featured-content slots stay null-safe (template uses optional chaining), so an empty list hides the three artwork tiles instead of breaking layout.

- **`apps/notifications/src/email/notifications/welcomeEmail.ts`** — `sendWelcomeEmail({ identityDb, userId, name, isNativeMobile? })`:
  - Looks up the user in identity (id, email, walletAddress, handle, isEmailDeliverable, isBlockedFromEmails) and returns a typed `{ sent: false, reason: 'no-user' | 'undeliverable' | 'blocked' | 'error' }` when the email shouldn't go out.
  - Best-effort fetches the top 3 monthly trending tracks for the body via `${DISCOVERY_PROVIDER_URL || https://discoveryprovider.audius.co}/v1/full/tracks/trending?limit=3&offset=0&time=month`. A failed fetch hides the artwork tiles but doesn't block the email.
  - Sends via the existing pedalboard `sendEmail` helper with `from: "The Audius Team <team@audius.co>"`, subject `Welcome to Audius! 👋`, and `asm.groupId: 23583` (the transactional-email unsubscribe group used by other pedalboard transactional sends).
  - Upserts `UserEvents.hasSignedInNativeMobile` so the existing signup-source analytics keep working.

- **`apps/notifications/src/server/routes/sendWelcomeEmail.ts` + `server/index.ts`** — `/internal/send-welcome-email` POST, Bearer-secret-protected via `WELCOME_EMAIL_SEND_SECRET` (mirrors [`sendAnnouncement.ts`](https://github.com/AudiusProject/pedalboard/blob/main/apps/notifications/src/server/routes/sendAnnouncement.ts)). The endpoint disables itself with a 503 when the secret env isn't set.

## Why an HTTP route instead of a pg-notify listener?

Pedalboard's existing event mechanism (`Listener` in `listener.ts`) only fires on inserts into the `notification` table. There is no `welcome` / `user_signup` notification type emitted by the discovery indexer's `create_user`, and the user creation event itself doesn't generate a notification row. The two analogous patterns in this service are:

- Notification mappers (e.g. `claimableReward.ts`, `usdcWithdrawal.ts`) — require a `notification` row from the indexer.
- Internal HTTP routes (`/internal/send-announcement`) — caller-driven, Bearer-secret-protected.

This PR uses the second pattern, which preserves the existing trigger semantics: identity-service's `/email/welcome` was also caller-driven (the signup flow POSTed to it after the user was created).

## Migration

The original identity-service `/email/welcome` route is left in place. A follow-up can either:
1. Point [`sendWelcomeEmail` in `AudiusBackend.ts`](https://github.com/AudiusProject/apps/blob/main/packages/common/src/services/audius-backend/AudiusBackend.ts#L674) at this endpoint (with a fresh secret-management story for the client), or
2. Have identity-service's existing route forward to this endpoint and eventually be removed.

## Test plan

- [ ] Local: set `WELCOME_EMAIL_SEND_SECRET=secret` + `SENDGRID_API_KEY`, POST to `/internal/send-welcome-email` with `{ userId, name }` for an identity user that has a deliverable email — email lands.
- [ ] Without `WELCOME_EMAIL_SEND_SECRET` set, the route returns 503.
- [ ] Without the Bearer header, the route returns 401.
- [ ] User with `isEmailDeliverable=false`: response is `{ sent: false, reason: 'undeliverable' }`, no SendGrid send.
- [ ] User with `isBlockedFromEmails=true`: response is `{ sent: false, reason: 'blocked' }`, no SendGrid send.
- [ ] Trending fetch failure (DN unreachable): email still sends, artwork tiles render with empty src/text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)