### PR TITLE
notifications: remove all email throttling (digest + transactional)

### DIFF
--- a/apps/notifications/src/config.ts
+++ b/apps/notifications/src/config.ts
@@ -23,9 +23,5 @@ export const config = {
   lastIndexedBlastUserIdRedisKey: 'latestBlastNotificationUserID',
   // Max retry-queue entries to LPOP per tick (was: lRange entire list every tick).
   notificationRetryBatchMax:
-    Number(process.env.NOTIFICATION_RETRY_BATCH_MAX) || 150,
-  // Unread-notification digest emails: send 1 / N attempts on average to cap SendGrid volume.
-  // N=1 disables sampling (always send). N=10 ≈ 10% of eligible sends. Skips do not write NotificationEmails.
-  notificationEmailSampleDenominator:
-    Number(process.env.NOTIFICATION_EMAIL_SAMPLE_DENOMINATOR) || 10
+    Number(process.env.NOTIFICATION_RETRY_BATCH_MAX) || 150
 }

--- a/apps/notifications/src/email/notifications/index.ts
+++ b/apps/notifications/src/email/notifications/index.ts
@@ -1,4 +1,3 @@
-import { randomInt } from 'crypto'
 import { Knex } from 'knex'
 import moment, { Moment } from 'moment-timezone'
 import { config } from '../../config'
@@ -407,23 +406,6 @@ const processGroupOfEmails = async (
 
             const user = userNotifications.user
             const notifications = userNotifications.notifications
-
-            const sampleDenom = Math.floor(
-              config.notificationEmailSampleDenominator
-            )
-            if (
-              Number.isFinite(sampleDenom) &&
-              sampleDenom > 1 &&
-              randomInt(sampleDenom) !== 0
-            ) {
-              logger.debug(
-                `processEmailNotifications | sampled out unread-notification email for user ${user.blockchainUserId} (1/${sampleDenom})`
-              )
-              return {
-                result: Results.SHOULD_SKIP,
-                error: 'Notification email skipped (send sampling)'
-              }
-            }
 
             // Set the timezone
             const sendAt = userNotificationSettings.getUserSendAt(

--- a/apps/notifications/src/email/notifications/sendEmail.ts
+++ b/apps/notifications/src/email/notifications/sendEmail.ts
@@ -1,7 +1,6 @@
 import { renderEmail } from './renderEmail'
 
 import { EmailNotification } from '../../types/notifications'
-import { config } from '../../config'
 import { logger } from '../../logger'
 import { getSendgrid } from '../../sendgrid'
 import { MailDataRequired } from '@sendgrid/mail'
@@ -126,45 +125,14 @@ type SendTransactionalEmailArgs = {
    * envelope.
    */
   from?: string
-  /**
-   * Skip the global transactional-email sample rate
-   * (`config.notificationEmailSampleDenominator`) and always send.
-   * Reserved for must-deliver flows where dropping the email would be
-   * a real bug — USDC purchase / transfer / withdrawal confirmations
-   * and account-management request emails. Defaults to `false`, so
-   * volume-heavy transactional sends (welcome, claimable reward,
-   * reward in cooldown) are sampled to cap SendGrid usage.
-   */
-  bypassSampling?: boolean
 }
 
 export const sendTransactionalEmail = async ({
   email,
   html,
   subject,
-  from = 'Audius <team@audius.co>',
-  bypassSampling = false
+  from = 'Audius <team@audius.co>'
 }: SendTransactionalEmailArgs) => {
-  // Sample 1-in-N of all non-bypassed transactional sends. Mirrors the
-  // existing digest-email sampling in processEmailNotifications (uses
-  // the same `notificationEmailSampleDenominator` knob) so volume can
-  // be tuned with one env var. The guard `sampleDenom > 1` makes
-  // `NOTIFICATION_EMAIL_SAMPLE_DENOMINATOR=1` a clean disable, and the
-  // `Number.isFinite` check avoids accidental "always skip" if someone
-  // sets the env to `Infinity` / a negative value.
-  if (!bypassSampling) {
-    const sampleDenom = Math.floor(config.notificationEmailSampleDenominator)
-    if (
-      Number.isFinite(sampleDenom) &&
-      sampleDenom > 1 &&
-      Math.random() > 1 / sampleDenom
-    ) {
-      logger.debug(
-        `sendTransactionalEmail | sampled out (1/${sampleDenom}) — to=${email}, subject=${subject}`
-      )
-      return false
-    }
-  }
   try {
     logger.debug(`SendTransactionalEmail | ${email}, ${subject}`)
     const emailParams = {

--- a/apps/notifications/src/email/notifications/welcomeEmail.ts
+++ b/apps/notifications/src/email/notifications/welcomeEmail.ts
@@ -155,15 +155,10 @@ export const sendWelcomeEmail = async ({
 
   const html = getWelcomeEmail({ name, copyrightYear, featuredContent })
 
-  // Route through sendTransactionalEmail so welcome inherits the global
-  // 1-in-N sample gate (`config.notificationEmailSampleDenominator`) the
-  // way claimable-reward / reward-in-cooldown do. The asm group (23583)
-  // is applied inside sendTransactionalEmail; we only override `from` so
-  // the welcome envelope reads "The Audius Team" instead of the
-  // default "Audius". A `false` return covers both an actual SendGrid
-  // failure (logged at error level) and a sample-out skip (logged at
-  // debug level) — both surface as `reason: 'error'` here, with the
-  // logs being the disambiguator.
+  // Route through sendTransactionalEmail (applies the asm group 23583).
+  // We only override `from` so the welcome envelope reads "The Audius
+  // Team" instead of the default "Audius". A `false` return indicates a
+  // SendGrid failure (logged at error level inside sendTransactionalEmail).
   const sent = await sendTransactionalEmail({
     email: user.email,
     html,

--- a/apps/notifications/src/processNotifications/mappers/requestManager.ts
+++ b/apps/notifications/src/processNotifications/mappers/requestManager.ts
@@ -118,9 +118,7 @@ export class RequestManager extends BaseNotification<RequestManagerRow> {
           managedAccountUser.user_id
         }`
       }),
-      subject: `Account Management Request`,
-      // Account-management security flow — never sample.
-      bypassSampling: true
+      subject: `Account Management Request`
     })
   }
 

--- a/apps/notifications/src/processNotifications/mappers/usdcPurchaseBuyer.ts
+++ b/apps/notifications/src/processNotifications/mappers/usdcPurchaseBuyer.ts
@@ -188,9 +188,7 @@ export class USDCPurchaseBuyer extends BaseNotification<USDCPurchaseBuyerRow> {
         total: this.totalAmount,
         vendor: this.vendor
       }),
-      subject: 'Thank you for your purchase!',
-      // Money-movement confirmation — never sample.
-      bypassSampling: true
+      subject: 'Thank you for your purchase!'
     })
   }
 

--- a/apps/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
+++ b/apps/notifications/src/processNotifications/mappers/usdcPurchaseSeller.ts
@@ -200,9 +200,7 @@ export class USDCPurchaseSeller extends BaseNotification<USDCPurchaseSellerRow> 
         payExtra: this.extraAmount,
         total: this.totalAmount
       }),
-      subject: `Congrats! You've made a sale on Audius!`,
-      // Money-movement confirmation — never sample.
-      bypassSampling: true
+      subject: `Congrats! You've made a sale on Audius!`
     })
   }
 

--- a/apps/notifications/src/processNotifications/mappers/usdcTransfer.ts
+++ b/apps/notifications/src/processNotifications/mappers/usdcTransfer.ts
@@ -61,9 +61,7 @@ export class USDCTransfer extends BaseNotification<USDCTransferRow> {
         wallet: this.receiverAccount,
         signature: this.signature
       }),
-      subject: 'Your USDC Transfer is Complete!',
-      // Money-movement confirmation — never sample.
-      bypassSampling: true
+      subject: 'Your USDC Transfer is Complete!'
     })
   }
 }

--- a/apps/notifications/src/processNotifications/mappers/usdcWithdrawal.ts
+++ b/apps/notifications/src/processNotifications/mappers/usdcWithdrawal.ts
@@ -59,9 +59,7 @@ export class USDCWithdrawal extends BaseNotification<USDCWithdrawalRow> {
         profileLink: formatProfileUrl(user.handle),
         amount: this.amount
       }),
-      subject: 'Your USDC Transfer is Complete!',
-      // Money-movement confirmation — never sample.
-      bypassSampling: true
+      subject: 'Your USDC Transfer is Complete!'
     })
   }
 }


### PR DESCRIPTION
## Summary

Removes both 1-in-N email sampling gates in the notifications worker. After this PR, every eligible notification email — digest and transactional — sends 100% of the time.

### Why

- **Daily/weekly digest** (`processEmailNotifications`): the sampler was added when emails went out per-event (the now-removed `EmailFrequency.Live`) to cap SendGrid volume. After the live→daily migration in [pedalboard#25](https://github.com/AudiusProject/pedalboard/pull/25) / [apps#14288](https://github.com/AudiusProject/apps/pull/14288), the daily/weekly cadence already caps volume. Sampler was silently dropping ~90% of digest emails on the floor — a "daily" user effectively got email every ~10 days.
- **Transactional** (`sendTransactionalEmail`): welcome / claimable-reward / reward-in-cooldown emails were sampled at the same 1-in-10 rate. These are event-driven, low-volume, must-deliver flows (a new user not getting their welcome email; a user not knowing their reward is ready). No volume problem to throttle against.

## Changes

- **[`sendEmail.ts`](https://github.com/AudiusProject/pedalboard/pull/31/files)** — remove the sampling block from `sendTransactionalEmail`; drop the now-dead `bypassSampling` prop from `SendTransactionalEmailArgs` and the now-unused `config` import.
- **[`index.ts`](https://github.com/AudiusProject/pedalboard/pull/31/files)** — remove the sampling block from `processEmailNotifications`; drop the now-unused `randomInt` import.
- **[`config.ts`](https://github.com/AudiusProject/pedalboard/pull/31/files)** — delete `notificationEmailSampleDenominator` (and its `NOTIFICATION_EMAIL_SAMPLE_DENOMINATOR` env var); no longer referenced.
- **`usdcPurchaseBuyer.ts`, `usdcPurchaseSeller.ts`, `usdcTransfer.ts`, `usdcWithdrawal.ts`, `requestManager.ts`** — strip `bypassSampling: true` (and its inline comment). Behavior unchanged for these five — they were already in the "always send" set.
- **`welcomeEmail.ts`** — update the comment that referenced the now-deleted gate.

## Deployment notes

If any deployment sets `NOTIFICATION_EMAIL_SAMPLE_DENOMINATOR`, it becomes a no-op after this lands. Safe to leave in env until the next config sweep — nothing reads it.

## Test plan

- [x] `npm run typecheck` clean in `apps/notifications`
- [x] Existing `sendTransactionalEmailSpy.toHaveBeenCalledWith(...)` assertions in `__tests__/mappings/{usdcPurchaseBuyer,usdcPurchaseSeller,usdcTransfer,usdcWithdrawal,requestManager}.test.ts` already omit `bypassSampling` — the source now matches the tests
- [ ] Staging: sign up a new account → welcome email lands every time
- [ ] Staging: trigger a claimable-reward and reward-in-cooldown notification → both emails land
- [ ] Staging: confirm `processEmailNotifications` log volume increases ~10× and `NotificationEmails` rows are written for ~all eligible users in a digest run (no more `'Notification email skipped (send sampling)'` results)
- [ ] SendGrid: confirm digest + welcome / claimable-reward / reward-in-cooldown volumes increase ~10×, no new bounce/spam spike

Note: full `npm test` requires a Postgres connection string; fails identically on `main` in a fresh checkout, so not a regression blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)