### PR TITLE
anti-abuse-oracle: bump @audius/sdk to 15.1.0

### DIFF
--- a/apps/anti-abuse-oracle/package.json
+++ b/apps/anti-abuse-oracle/package.json
@@ -15,7 +15,7 @@
     "preset": "jest-presets/jest/node"
   },
   "dependencies": {
-    "@audius/sdk": "5.0.0",
+    "@audius/sdk": "15.1.0",
     "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
     "@hono/node-server": "1.19.1",
     "@pedalboard/basekit": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,30 +25,26 @@
       "name": "@pedalboard/anti-abuse-oracle",
       "version": "0.0.30",
       "dependencies": {
-        "@audius/sdk": "4.1.1-beta.1",
+        "@audius/sdk": "15.1.0",
+        "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
         "@hono/node-server": "1.19.1",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
         "@pedalboard/storage": "*",
-        "body-parser": "1.20.3",
-        "cors": "2.8.5",
+        "@solana/web3.js": "1.98.4",
+        "bn.js": "5.2.1",
         "cross-fetch": "4.0.0",
         "dotenv": "16.6.1",
-        "express": "4.17.1",
+        "envalid": "8.0.0",
         "hono": "4.9.5",
-        "morgan": "1.10.1",
         "pino": "9.0.0",
         "postgres": "3.4.7"
       },
       "devDependencies": {
-        "@types/body-parser": "1.19.6",
-        "@types/cors": "2.8.10",
-        "@types/express": "4.17.12",
+        "@types/bn.js": "5.2.0",
         "@types/jest": "26.0.24",
-        "@types/morgan": "1.9.10",
         "@types/node": "15.14.9",
         "@types/supertest": "2.0.16",
-        "envalid": "8.0.0",
         "esbuild": "0.14.38",
         "esbuild-register": "3.3.2",
         "eslint": "8.56.0",
@@ -62,38 +58,21 @@
       }
     },
     "apps/anti-abuse-oracle/node_modules/@audius/fixed-decimal": {
-      "version": "0.0.25",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.1.0.tgz",
+      "integrity": "sha512-iwafMiqtRuf3eaE+j/EDqAkRRxtWB8g/QgqukUbw2D1KiYiSZblakWs7Q+tdnTBKml1oB0nrGHSKvVPEBxbSRQ==",
       "license": "Apache-2.0"
     },
-    "apps/anti-abuse-oracle/node_modules/@audius/hedgehog": {
-      "version": "3.0.0-alpha.0",
-      "license": "MIT",
-      "dependencies": {
-        "bip39": "3.0.4",
-        "browserify-cipher": "1.0.1",
-        "ethereumjs-wallet": "1.0.2",
-        "node-localstorage": "2.2.1",
-        "randombytes": "2.1.0",
-        "safe-buffer": "5.2.1"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/hedgehog/node_modules/node-localstorage": {
-      "version": "2.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "write-file-atomic": "^1.1.4"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/sdk": {
-      "version": "4.1.1-beta.1",
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy": {
+      "name": "@audius/sdk",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-5.0.0.tgz",
+      "integrity": "sha512-W8nBFdNIADbwU2YNIDXJL44Qx+wf7RtNZ47Ttv/tI7p1+hLMPpJU8gq7YXK5gZvx9NGgQMWSVAQQ1nCra7HbRw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@audius/fixed-decimal": "0.0.25",
-        "@audius/hedgehog": "3.0.0-alpha.0",
-        "@audius/spl": "1.0.0",
+        "@audius/fixed-decimal": "0.1.0",
+        "@audius/hedgehog": "3.0.0-alpha.1",
+        "@audius/spl": "1.0.1",
         "@babel/core": "^7.23.7",
         "@babel/plugin-proposal-class-static-block": "7.21.0",
         "@babel/runtime": "7.18.3",
@@ -105,7 +84,7 @@
         "@project-serum/anchor": "0.24.1",
         "@scure/base": "1.1.1",
         "@solana/spl-token": "0.3.8",
-        "@solana/web3.js": "1.78.4",
+        "@solana/web3.js": "1.93.4",
         "abi-decoder": "2.4.0",
         "ajv": "6.12.2",
         "assert": "2.0.0",
@@ -158,8 +137,53 @@
         "node": ">=14.0.0"
       }
     },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy/node_modules/@solana/web3.js": {
+      "version": "1.93.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
+      "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
+        "bigint-buffer": "^1.1.5",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.0",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^1.0.4"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy/node_modules/@solana/web3.js/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy/node_modules/@solana/web3.js/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
     "apps/anti-abuse-oracle/node_modules/@audius/spl": {
-      "version": "1.0.0",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@audius/spl/-/spl-1.0.1.tgz",
+      "integrity": "sha512-vhW1UEzQHPeMuxuYGIiJJoD+a8l7Ui7Fqsne5R1LcFXJek5dlKTAvILY9qWSqWRFeAIVY8Uo/dKmmJ1Y2OteIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@coral-xyz/anchor": "0.29.0",
@@ -167,11 +191,56 @@
         "@solana/buffer-layout": "4.0.1",
         "@solana/buffer-layout-utils": "0.2.0",
         "@solana/spl-token": "0.3.8",
-        "@solana/web3.js": "1.78.4"
+        "@solana/web3.js": "1.93.4"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/spl/node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/spl/node_modules/@solana/web3.js": {
+      "version": "1.93.4",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
+      "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.24.7",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
+        "bigint-buffer": "^1.1.5",
+        "bn.js": "^5.2.1",
+        "borsh": "^0.7.0",
+        "bs58": "^4.0.1",
+        "buffer": "6.0.3",
+        "fast-stable-stringify": "^1.0.0",
+        "jayson": "^4.1.0",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^9.0.2",
+        "superstruct": "^1.0.4"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/spl/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
       }
     },
     "apps/anti-abuse-oracle/node_modules/@ethersproject/abstract-provider": {
       "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+      "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
       "funding": [
         {
           "type": "individual",
@@ -207,6 +276,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/bytes": "^5.4.0",
         "@ethersproject/logger": "^5.4.0",
@@ -216,7 +286,8 @@
     "apps/anti-abuse-oracle/node_modules/@ethersproject/bignumber/node_modules/bn.js": {
       "version": "4.12.3",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
+      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
+      "license": "MIT"
     },
     "apps/anti-abuse-oracle/node_modules/@ethersproject/bytes": {
       "version": "5.4.0",
@@ -232,6 +303,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -249,7 +321,8 @@
           "type": "individual",
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "apps/anti-abuse-oracle/node_modules/@ethersproject/networks": {
       "version": "5.4.2",
@@ -265,6 +338,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -283,6 +357,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/logger": "^5.4.0"
       }
@@ -301,6 +376,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/address": "^5.4.0",
         "@ethersproject/bignumber": "^5.4.0",
@@ -327,6 +403,7 @@
           "url": "https://www.buymeacoffee.com/ricmoo"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/base64": "^5.4.0",
         "@ethersproject/bytes": "^5.4.0",
@@ -337,79 +414,14 @@
     },
     "apps/anti-abuse-oracle/node_modules/@noble/hashes": {
       "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "license": "MIT",
       "engines": {
         "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@solana/web3.js": {
-      "version": "1.78.4",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@noble/curves": "^1.0.0",
-        "@noble/hashes": "^1.3.1",
-        "@solana/buffer-layout": "^4.0.0",
-        "agentkeepalive": "^4.3.0",
-        "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.2.1",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.0",
-        "node-fetch": "^2.6.12",
-        "rpc-websockets": "^7.5.1",
-        "superstruct": "^0.14.2"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@solana/web3.js/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@solana/web3.js/node_modules/borsh": {
-      "version": "0.7.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@types/bn.js": {
-      "version": "4.11.6",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@types/body-parser": {
-      "version": "1.19.6",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@types/morgan": {
-      "version": "1.9.10",
-      "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
-      "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "apps/anti-abuse-oracle/node_modules/@types/node": {
@@ -430,41 +442,30 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+      "license": "MIT",
       "dependencies": {
         "follow-redirects": "1.5.10"
       }
     },
-    "apps/anti-abuse-oracle/node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "content-type": "~1.0.5",
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
-        "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8",
-        "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
     "apps/anti-abuse-oracle/node_modules/borsh": {
       "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
+      "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.5",
         "bn.js": "^5.0.0",
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/borsh/node_modules/@types/bn.js": {
+      "version": "4.11.6",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+      "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "apps/anti-abuse-oracle/node_modules/cross-fetch": {
@@ -488,6 +489,8 @@
     },
     "apps/anti-abuse-oracle/node_modules/elliptic": {
       "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.9",
@@ -507,6 +510,9 @@
     },
     "apps/anti-abuse-oracle/node_modules/eth-sig-util": {
       "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
+      "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
+      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
       "license": "ISC",
       "dependencies": {
         "ethereumjs-abi": "0.6.8",
@@ -523,6 +529,8 @@
     },
     "apps/anti-abuse-oracle/node_modules/eth-sig-util/node_modules/ethereumjs-util": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
       "license": "MPL-2.0",
       "dependencies": {
         "bn.js": "^4.11.0",
@@ -536,6 +544,8 @@
     },
     "apps/anti-abuse-oracle/node_modules/ethers": {
       "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
+      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
       "funding": [
         {
           "type": "individual",
@@ -582,6 +592,8 @@
     },
     "apps/anti-abuse-oracle/node_modules/ethers/node_modules/@ethersproject/solidity": {
       "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
       "funding": [
         {
           "type": "individual",
@@ -603,6 +615,8 @@
     },
     "apps/anti-abuse-oracle/node_modules/keccak256": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.2.tgz",
+      "integrity": "sha512-f2EncSgmHmmQOkgxZ+/f2VaWTNkFL6f39VIrpoX+p8cEXJVyyCs/3h9GNz/ViHgwchxvv7oG5mjT2Tk4ZqInag==",
       "license": "MIT",
       "dependencies": {
         "bn.js": "^4.11.8",
@@ -615,34 +629,10 @@
       "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
       "license": "MIT"
     },
-    "apps/anti-abuse-oracle/node_modules/morgan": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-      "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
-      "dependencies": {
-        "basic-auth": "~2.0.1",
-        "debug": "2.6.9",
-        "depd": "~2.0.0",
-        "on-finished": "~2.3.0",
-        "on-headers": "~1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/morgan/node_modules/on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-      "dependencies": {
-        "ee-first": "1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "apps/anti-abuse-oracle/node_modules/multiformats": {
       "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
       "license": "(Apache-2.0 AND MIT)"
     },
     "apps/anti-abuse-oracle/node_modules/pino": {
@@ -691,25 +681,10 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "apps/anti-abuse-oracle/node_modules/rpc-websockets": {
-      "version": "7.11.2",
-      "license": "LGPL-3.0-only",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "uuid": "^8.3.2",
-        "ws": "^8.5.0"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/kozjak"
-      },
-      "optionalDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      }
-    },
     "apps/anti-abuse-oracle/node_modules/secp256k1": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -722,8 +697,13 @@
       }
     },
     "apps/anti-abuse-oracle/node_modules/superstruct": {
-      "version": "0.14.2",
-      "license": "MIT"
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "apps/anti-abuse-oracle/node_modules/typescript": {
       "version": "5.0.4",
@@ -735,15 +715,6 @@
       },
       "engines": {
         "node": ">=12.20"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/write-file-atomic": {
-      "version": "1.3.4",
-      "license": "ISC",
-      "dependencies": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "slide": "^1.1.5"
       }
     },
     "apps/app-template": {
@@ -1149,16 +1120,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "apps/archiver/node_modules/viem/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "apps/backfill-audio-analyses": {
@@ -3482,16 +3443,6 @@
         }
       }
     },
-    "apps/relay/node_modules/viem/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "apps/sla-auditor": {
       "name": "@pedalboard/sla-auditor",
       "version": "0.0.30",
@@ -4789,17 +4740,6 @@
         }
       }
     },
-    "apps/trending-challenge-rewards/node_modules/viem/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "apps/verified-notifications": {
       "name": "@pedalboard/verified-notifications",
       "version": "0.1.0",
@@ -5252,20 +5192,6 @@
         }
       }
     },
-    "node_modules/@audius/eth/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@audius/eth/node_modules/viem": {
       "version": "2.21.21",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
@@ -5294,16 +5220,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@audius/eth/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@audius/fixed-decimal": {
@@ -5349,7 +5265,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.1.0.tgz",
       "integrity": "sha512-g2ltIqqd8ziIIBzzBIiYlmEjdEfWMKz0pJHlBj53JiCL8blqUD/ltBFwSGZk3vpOBqamBIFmRZSjdSzMDIsZ6A==",
-      "dev": true,
       "dependencies": {
         "@audius/eth": "1.0.0",
         "@audius/fixed-decimal": "0.2.1",
@@ -5969,20 +5884,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@audius/sdk-legacy/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@audius/sdk-legacy/node_modules/viem": {
       "version": "2.21.21",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
@@ -6044,27 +5945,15 @@
         }
       }
     },
-    "node_modules/@audius/sdk-legacy/node_modules/viem/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@audius/sdk/node_modules/@audius/eth": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
-      "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
-      "dev": true
+      "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
     },
     "node_modules/@audius/sdk/node_modules/@noble/curves": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
       "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
-      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.5.0"
       },
@@ -6079,7 +5968,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6091,7 +5979,6 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6101,7 +5988,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "1.5.10"
       }
@@ -6110,7 +5996,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
       "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
-      "dev": true,
       "dependencies": {
         "@types/bn.js": "^4.11.5",
         "bn.js": "^5.0.0",
@@ -6122,31 +6007,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
       "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-      "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
-      }
-    },
-    "node_modules/@audius/sdk/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@audius/sdk/node_modules/viem": {
       "version": "2.21.21",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
       "integrity": "sha512-KJPqpAXy8kyZQICx1nURUXqd8aABP9RweAZhfp27MzMPsAAxP450cWPlEffEAUrvsyyj5edVbIcHESE8DYVzFA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6177,7 +6045,6 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6189,7 +6056,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
       "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -6204,17 +6070,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@audius/sdk/node_modules/viem/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@audius/spl": {
@@ -10963,21 +10818,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
       "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
     },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@injectivelabs/sdk-ts/node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -11051,17 +10891,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@injectivelabs/sdk-ts/node_modules/zod": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@injectivelabs/tc-abacus-proto-ts-v2": {
@@ -29130,17 +28959,6 @@
         }
       }
     },
-    "node_modules/inquirer/node_modules/@types/node": {
-      "version": "25.7.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.21.0"
-      }
-    },
     "node_modules/inquirer/node_modules/iconv-lite": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -29155,14 +28973,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/inquirer/node_modules/undici-types": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/interface-blockstore": {
       "version": "2.0.3",
@@ -42895,13 +42705,6 @@
           "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
           "requires": {}
         },
-        "typescript": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-          "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-          "optional": true,
-          "peer": true
-        },
         "viem": {
           "version": "2.21.21",
           "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
@@ -42917,13 +42720,6 @@
             "webauthn-p256": "0.0.10",
             "ws": "8.18.0"
           }
-        },
-        "zod": {
-          "version": "3.25.76",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-          "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -42969,7 +42765,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.1.0.tgz",
       "integrity": "sha512-g2ltIqqd8ziIIBzzBIiYlmEjdEfWMKz0pJHlBj53JiCL8blqUD/ltBFwSGZk3vpOBqamBIFmRZSjdSzMDIsZ6A==",
-      "dev": true,
       "requires": {
         "@audius/eth": "1.0.0",
         "@audius/fixed-decimal": "0.2.1",
@@ -43012,14 +42807,12 @@
         "@audius/eth": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
-          "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
-          "dev": true
+          "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
         },
         "@noble/curves": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
           "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
-          "dev": true,
           "requires": {
             "@noble/hashes": "1.5.0"
           },
@@ -43027,8 +42820,7 @@
             "@noble/hashes": {
               "version": "1.5.0",
               "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-              "dev": true
+              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
             }
           }
         },
@@ -43036,7 +42828,6 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-          "dev": true,
           "requires": {
             "@types/node": "*"
           }
@@ -43045,7 +42836,6 @@
           "version": "0.19.2",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
           "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "dev": true,
           "requires": {
             "follow-redirects": "1.5.10"
           }
@@ -43054,7 +42844,6 @@
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
           "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
-          "dev": true,
           "requires": {
             "@types/bn.js": "^4.11.5",
             "bn.js": "^5.0.0",
@@ -43066,24 +42855,14 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
           "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
-          "dev": true,
           "requires": {
             "node-fetch": "^2.6.12"
           }
-        },
-        "typescript": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-          "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
         },
         "viem": {
           "version": "2.21.21",
           "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
           "integrity": "sha512-KJPqpAXy8kyZQICx1nURUXqd8aABP9RweAZhfp27MzMPsAAxP450cWPlEffEAUrvsyyj5edVbIcHESE8DYVzFA==",
-          "dev": true,
           "requires": {
             "@adraffy/ens-normalize": "1.11.0",
             "@noble/curves": "1.6.0",
@@ -43099,23 +42878,13 @@
             "@noble/hashes": {
               "version": "1.5.0",
               "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
-              "dev": true
+              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
             },
             "abitype": {
               "version": "1.0.6",
               "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
               "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
-              "dev": true,
               "requires": {}
-            },
-            "zod": {
-              "version": "3.25.76",
-              "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-              "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-              "dev": true,
-              "optional": true,
-              "peer": true
             }
           }
         }
@@ -43553,13 +43322,6 @@
           "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
           "integrity": "sha512-uV+TFRZdXsqXTL2pRvujROjdZQ4RAlBUS5BTh9IGm+jTqQntYThciG/qu57Gs69yjnVUSqdxF9YLmSnpupBW9A=="
         },
-        "typescript": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-          "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-          "optional": true,
-          "peer": true
-        },
         "viem": {
           "version": "2.21.21",
           "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
@@ -43586,13 +43348,6 @@
               "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
               "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
               "requires": {}
-            },
-            "zod": {
-              "version": "3.25.76",
-              "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-              "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-              "optional": true,
-              "peer": true
             }
           }
         }
@@ -46803,13 +46558,6 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
           "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
         },
-        "typescript": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-          "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-          "optional": true,
-          "peer": true
-        },
         "undici-types": {
           "version": "6.19.8",
           "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
@@ -46843,13 +46591,6 @@
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
           "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
           "requires": {}
-        },
-        "zod": {
-          "version": "4.4.3",
-          "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
-          "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -49593,20 +49334,18 @@
     "@pedalboard/anti-abuse-oracle": {
       "version": "file:apps/anti-abuse-oracle",
       "requires": {
-        "@audius/sdk": "4.1.1-beta.1",
+        "@audius/sdk": "15.1.0",
+        "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
         "@hono/node-server": "1.19.1",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
         "@pedalboard/storage": "*",
-        "@types/body-parser": "1.19.6",
-        "@types/cors": "2.8.10",
-        "@types/express": "4.17.12",
+        "@solana/web3.js": "1.98.4",
+        "@types/bn.js": "5.2.0",
         "@types/jest": "26.0.24",
-        "@types/morgan": "1.9.10",
         "@types/node": "15.14.9",
         "@types/supertest": "2.0.16",
-        "body-parser": "1.20.3",
-        "cors": "2.8.5",
+        "bn.js": "5.2.1",
         "cross-fetch": "4.0.0",
         "dotenv": "16.6.1",
         "envalid": "8.0.0",
@@ -49614,11 +49353,9 @@
         "esbuild-register": "3.3.2",
         "eslint": "8.56.0",
         "eslint-config-custom-server": "*",
-        "express": "4.17.1",
         "hono": "4.9.5",
         "jest": "26.6.3",
         "jest-presets": "*",
-        "morgan": "1.10.1",
         "nodemon": "2.0.22",
         "pino": "9.0.0",
         "postgres": "3.4.7",
@@ -49628,33 +49365,18 @@
       },
       "dependencies": {
         "@audius/fixed-decimal": {
-          "version": "0.0.25"
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.1.0.tgz",
+          "integrity": "sha512-iwafMiqtRuf3eaE+j/EDqAkRRxtWB8g/QgqukUbw2D1KiYiSZblakWs7Q+tdnTBKml1oB0nrGHSKvVPEBxbSRQ=="
         },
-        "@audius/hedgehog": {
-          "version": "3.0.0-alpha.0",
+        "@audius/sdk-legacy": {
+          "version": "npm:@audius/sdk@5.0.0",
+          "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-5.0.0.tgz",
+          "integrity": "sha512-W8nBFdNIADbwU2YNIDXJL44Qx+wf7RtNZ47Ttv/tI7p1+hLMPpJU8gq7YXK5gZvx9NGgQMWSVAQQ1nCra7HbRw==",
           "requires": {
-            "bip39": "3.0.4",
-            "browserify-cipher": "1.0.1",
-            "ethereumjs-wallet": "1.0.2",
-            "node-localstorage": "2.2.1",
-            "randombytes": "2.1.0",
-            "safe-buffer": "5.2.1"
-          },
-          "dependencies": {
-            "node-localstorage": {
-              "version": "2.2.1",
-              "requires": {
-                "write-file-atomic": "^1.1.4"
-              }
-            }
-          }
-        },
-        "@audius/sdk": {
-          "version": "4.1.1-beta.1",
-          "requires": {
-            "@audius/fixed-decimal": "0.0.25",
-            "@audius/hedgehog": "3.0.0-alpha.0",
-            "@audius/spl": "1.0.0",
+            "@audius/fixed-decimal": "0.1.0",
+            "@audius/hedgehog": "3.0.0-alpha.1",
+            "@audius/spl": "1.0.1",
             "@babel/core": "^7.23.7",
             "@babel/plugin-proposal-class-static-block": "7.21.0",
             "@babel/runtime": "7.18.3",
@@ -49666,7 +49388,7 @@
             "@project-serum/anchor": "0.24.1",
             "@scure/base": "1.1.1",
             "@solana/spl-token": "0.3.8",
-            "@solana/web3.js": "1.78.4",
+            "@solana/web3.js": "1.93.4",
             "abi-decoder": "2.4.0",
             "ajv": "6.12.2",
             "assert": "2.0.0",
@@ -49714,21 +49436,105 @@
             "web3": "1.8.2",
             "xmlhttprequest": "1.8.0",
             "zod": "3.21.4"
+          },
+          "dependencies": {
+            "@solana/web3.js": {
+              "version": "1.93.4",
+              "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
+              "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
+              "requires": {
+                "@babel/runtime": "^7.24.7",
+                "@noble/curves": "^1.4.0",
+                "@noble/hashes": "^1.4.0",
+                "@solana/buffer-layout": "^4.0.1",
+                "agentkeepalive": "^4.5.0",
+                "bigint-buffer": "^1.1.5",
+                "bn.js": "^5.2.1",
+                "borsh": "^0.7.0",
+                "bs58": "^4.0.1",
+                "buffer": "6.0.3",
+                "fast-stable-stringify": "^1.0.0",
+                "jayson": "^4.1.0",
+                "node-fetch": "^2.7.0",
+                "rpc-websockets": "^9.0.2",
+                "superstruct": "^1.0.4"
+              },
+              "dependencies": {
+                "@babel/runtime": {
+                  "version": "7.29.2",
+                  "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+                  "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+                },
+                "borsh": {
+                  "version": "0.7.0",
+                  "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+                  "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+                  "requires": {
+                    "bn.js": "^5.2.0",
+                    "bs58": "^4.0.0",
+                    "text-encoding-utf-8": "^1.0.2"
+                  }
+                }
+              }
+            }
           }
         },
         "@audius/spl": {
-          "version": "1.0.0",
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/@audius/spl/-/spl-1.0.1.tgz",
+          "integrity": "sha512-vhW1UEzQHPeMuxuYGIiJJoD+a8l7Ui7Fqsne5R1LcFXJek5dlKTAvILY9qWSqWRFeAIVY8Uo/dKmmJ1Y2OteIA==",
           "requires": {
             "@coral-xyz/anchor": "0.29.0",
             "@noble/hashes": "1.4.0",
             "@solana/buffer-layout": "4.0.1",
             "@solana/buffer-layout-utils": "0.2.0",
             "@solana/spl-token": "0.3.8",
-            "@solana/web3.js": "1.78.4"
+            "@solana/web3.js": "1.93.4"
+          },
+          "dependencies": {
+            "@babel/runtime": {
+              "version": "7.29.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+              "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
+            },
+            "@solana/web3.js": {
+              "version": "1.93.4",
+              "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
+              "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
+              "requires": {
+                "@babel/runtime": "^7.24.7",
+                "@noble/curves": "^1.4.0",
+                "@noble/hashes": "^1.4.0",
+                "@solana/buffer-layout": "^4.0.1",
+                "agentkeepalive": "^4.5.0",
+                "bigint-buffer": "^1.1.5",
+                "bn.js": "^5.2.1",
+                "borsh": "^0.7.0",
+                "bs58": "^4.0.1",
+                "buffer": "6.0.3",
+                "fast-stable-stringify": "^1.0.0",
+                "jayson": "^4.1.0",
+                "node-fetch": "^2.7.0",
+                "rpc-websockets": "^9.0.2",
+                "superstruct": "^1.0.4"
+              }
+            },
+            "borsh": {
+              "version": "0.7.0",
+              "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+              "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+              "requires": {
+                "bn.js": "^5.2.0",
+                "bs58": "^4.0.0",
+                "text-encoding-utf-8": "^1.0.2"
+              }
+            }
           }
         },
         "@ethersproject/abstract-provider": {
           "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
+          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
           "requires": {
             "@ethersproject/bignumber": "^5.4.0",
             "@ethersproject/bytes": "^5.4.0",
@@ -49814,69 +49620,9 @@
           }
         },
         "@noble/hashes": {
-          "version": "1.4.0"
-        },
-        "@solana/web3.js": {
-          "version": "1.78.4",
-          "requires": {
-            "@babel/runtime": "^7.22.6",
-            "@noble/curves": "^1.0.0",
-            "@noble/hashes": "^1.3.1",
-            "@solana/buffer-layout": "^4.0.0",
-            "agentkeepalive": "^4.3.0",
-            "bigint-buffer": "^1.1.5",
-            "bn.js": "^5.2.1",
-            "borsh": "^0.7.0",
-            "bs58": "^4.0.1",
-            "buffer": "6.0.3",
-            "fast-stable-stringify": "^1.0.0",
-            "jayson": "^4.1.0",
-            "node-fetch": "^2.6.12",
-            "rpc-websockets": "^7.5.1",
-            "superstruct": "^0.14.2"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.29.2",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-              "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
-            },
-            "borsh": {
-              "version": "0.7.0",
-              "requires": {
-                "bn.js": "^5.2.0",
-                "bs58": "^4.0.0",
-                "text-encoding-utf-8": "^1.0.2"
-              }
-            }
-          }
-        },
-        "@types/bn.js": {
-          "version": "4.11.6",
-          "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
-          "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "@types/body-parser": {
-          "version": "1.19.6",
-          "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
-          "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-          "dev": true,
-          "requires": {
-            "@types/connect": "*",
-            "@types/node": "*"
-          }
-        },
-        "@types/morgan": {
-          "version": "1.9.10",
-          "resolved": "https://registry.npmjs.org/@types/morgan/-/morgan-1.9.10.tgz",
-          "integrity": "sha512-sS4A1zheMvsADRVfT0lYbJ4S9lmsey8Zo2F7cnbYjWHP67Q0AwMYuuzLlkIM2N8gAbb9cubhIVFwcIN2XyYCkA==",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+          "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
         },
         "@types/node": {
           "version": "15.14.9"
@@ -49898,32 +49644,25 @@
             "follow-redirects": "1.5.10"
           }
         },
-        "body-parser": {
-          "version": "1.20.3",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-          "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
-          "requires": {
-            "bytes": "3.1.2",
-            "content-type": "~1.0.5",
-            "debug": "2.6.9",
-            "depd": "2.0.0",
-            "destroy": "1.2.0",
-            "http-errors": "2.0.0",
-            "iconv-lite": "0.4.24",
-            "on-finished": "2.4.1",
-            "qs": "6.13.0",
-            "raw-body": "2.5.2",
-            "type-is": "~1.6.18",
-            "unpipe": "1.0.0"
-          }
-        },
         "borsh": {
           "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
+          "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
           "requires": {
             "@types/bn.js": "^4.11.5",
             "bn.js": "^5.0.0",
             "bs58": "^4.0.0",
             "text-encoding-utf-8": "^1.0.2"
+          },
+          "dependencies": {
+            "@types/bn.js": {
+              "version": "4.11.6",
+              "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+              "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+              "requires": {
+                "@types/node": "*"
+              }
+            }
           }
         },
         "cross-fetch": {
@@ -49941,6 +49680,8 @@
         },
         "elliptic": {
           "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
           "requires": {
             "bn.js": "^4.11.9",
             "brorand": "^1.1.0",
@@ -49960,6 +49701,8 @@
         },
         "eth-sig-util": {
           "version": "2.5.4",
+          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
+          "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
           "requires": {
             "ethereumjs-abi": "0.6.8",
             "ethereumjs-util": "^5.1.1",
@@ -49974,6 +49717,8 @@
             },
             "ethereumjs-util": {
               "version": "5.2.1",
+              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
+              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "requires": {
                 "bn.js": "^4.11.0",
                 "create-hash": "^1.1.2",
@@ -49988,6 +49733,8 @@
         },
         "ethers": {
           "version": "5.4.7",
+          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
+          "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
           "requires": {
             "@ethersproject/abi": "5.4.1",
             "@ethersproject/abstract-provider": "5.4.1",
@@ -50023,6 +49770,8 @@
           "dependencies": {
             "@ethersproject/solidity": {
               "version": "5.4.0",
+              "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
+              "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
               "requires": {
                 "@ethersproject/bignumber": "^5.4.0",
                 "@ethersproject/bytes": "^5.4.0",
@@ -50035,6 +49784,8 @@
         },
         "keccak256": {
           "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.2.tgz",
+          "integrity": "sha512-f2EncSgmHmmQOkgxZ+/f2VaWTNkFL6f39VIrpoX+p8cEXJVyyCs/3h9GNz/ViHgwchxvv7oG5mjT2Tk4ZqInag==",
           "requires": {
             "bn.js": "^4.11.8",
             "keccak": "^3.0.1"
@@ -50047,30 +49798,10 @@
             }
           }
         },
-        "morgan": {
-          "version": "1.10.1",
-          "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-          "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
-          "requires": {
-            "basic-auth": "~2.0.1",
-            "debug": "2.6.9",
-            "depd": "~2.0.0",
-            "on-finished": "~2.3.0",
-            "on-headers": "~1.1.0"
-          },
-          "dependencies": {
-            "on-finished": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
-              "requires": {
-                "ee-first": "1.1.1"
-              }
-            }
-          }
-        },
         "multiformats": {
-          "version": "9.9.0"
+          "version": "9.9.0",
+          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
+          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
         },
         "pino": {
           "version": "9.0.0",
@@ -50108,18 +49839,10 @@
             "string_decoder": "^1.3.0"
           }
         },
-        "rpc-websockets": {
-          "version": "7.11.2",
-          "requires": {
-            "bufferutil": "^4.0.1",
-            "eventemitter3": "^4.0.7",
-            "utf-8-validate": "^5.0.2",
-            "uuid": "^8.3.2",
-            "ws": "^8.5.0"
-          }
-        },
         "secp256k1": {
           "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
+          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "requires": {
             "elliptic": "^6.5.2",
             "node-addon-api": "^2.0.0",
@@ -50127,19 +49850,13 @@
           }
         },
         "superstruct": {
-          "version": "0.14.2"
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
+          "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="
         },
         "typescript": {
           "version": "5.0.4",
           "dev": true
-        },
-        "write-file-atomic": {
-          "version": "1.3.4",
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
-          }
         }
       }
     },
@@ -50451,13 +50168,6 @@
               "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
               "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
               "requires": {}
-            },
-            "zod": {
-              "version": "3.25.76",
-              "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-              "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-              "optional": true,
-              "peer": true
             }
           }
         }
@@ -52144,13 +51854,6 @@
               "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
               "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
               "requires": {}
-            },
-            "zod": {
-              "version": "3.25.76",
-              "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-              "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-              "optional": true,
-              "peer": true
             }
           }
         }
@@ -53111,13 +52814,6 @@
               "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
               "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
               "requires": {}
-            },
-            "zod": {
-              "version": "3.25.76",
-              "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-              "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-              "optional": true,
-              "peer": true
             }
           }
         }
@@ -63929,16 +63625,6 @@
             "iconv-lite": "^0.7.0"
           }
         },
-        "@types/node": {
-          "version": "25.7.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
-          "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "undici-types": "~7.21.0"
-          }
-        },
         "iconv-lite": {
           "version": "0.7.2",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
@@ -63946,13 +63632,6 @@
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
-        },
-        "undici-types": {
-          "version": "7.21.0",
-          "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.21.0.tgz",
-          "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==",
-          "optional": true,
-          "peer": true
         }
       }
     },


### PR DESCRIPTION
## Summary
- Bump `@audius/sdk` in `apps/anti-abuse-oracle/package.json` from `5.0.0` to `15.1.0` to match `apps/solana-relay`.
- Regenerate `package-lock.json`, which was badly out of sync (it pinned AAO to `@audius/sdk@4.1.1-beta.1` with a pre-migration dependency list including express/cors/morgan that aren't actually in the package.json anymore).
- No source changes needed: at 15.1.0 the `sdk({ appName, environment })` initializer in [apps/anti-abuse-oracle/src/sdk.ts](apps/anti-abuse-oracle/src/sdk.ts) is still supported, `getUserByHandle` still returns `{ data: User }` (already fixed in c125ed4), and `HashId` is still exported from `@audius/sdk`.

`@audius/sdk-legacy` is left at the existing `npm:@audius/sdk@5.0.0` alias since it provides `SolanaUtils`/`Utils` helpers that AAO still uses and that aren't surfaced the same way from the new SDK.

## Test plan
- [x] `npm run build --workspace=@pedalboard/anti-abuse-oracle` — clean
- [x] `npm run lint --workspace=@pedalboard/anti-abuse-oracle` — clean (4 pre-existing non-null-assertion warnings unchanged)
- [ ] Smoke-test `/attestation/:handle` endpoint against a known user once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)