### PR TITLE
chore(aao): bump @audius/sdk to 15.3.1 to fix lodash ESM crash

### DIFF
--- a/apps/anti-abuse-oracle/package.json
+++ b/apps/anti-abuse-oracle/package.json
@@ -15,7 +15,7 @@
     "preset": "jest-presets/jest/node"
   },
   "dependencies": {
-    "@audius/sdk": "15.1.0",
+    "@audius/sdk": "^15.3.1",
     "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
     "@hono/node-server": "1.19.1",
     "@pedalboard/basekit": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "name": "@pedalboard/anti-abuse-oracle",
       "version": "0.0.30",
       "dependencies": {
-        "@audius/sdk": "15.1.0",
+        "@audius/sdk": "^15.3.1",
         "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
         "@hono/node-server": "1.19.1",
         "@pedalboard/basekit": "*",
@@ -57,11 +57,78 @@
         "typescript": "5.0.4"
       }
     },
+    "apps/anti-abuse-oracle/node_modules/@audius/eth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
+      "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
+      "license": "Apache-2.0"
+    },
     "apps/anti-abuse-oracle/node_modules/@audius/fixed-decimal": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.1.0.tgz",
       "integrity": "sha512-iwafMiqtRuf3eaE+j/EDqAkRRxtWB8g/QgqukUbw2D1KiYiSZblakWs7Q+tdnTBKml1oB0nrGHSKvVPEBxbSRQ==",
       "license": "Apache-2.0"
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk": {
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.3.1.tgz",
+      "integrity": "sha512-cUGQXdUaaqd2uGm6Xa/vgHEKIenJsA/HWb30SzIv5dpILjsBK79ZM7+dBoT84TV0CsNJLuMn+wt1pbgcrOWtiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@audius/eth": "1.0.0",
+        "@audius/fixed-decimal": "0.2.1",
+        "@audius/hedgehog": "3.0.0-alpha.1",
+        "@audius/spl": "2.1.0",
+        "@babel/runtime": "7.18.3",
+        "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
+        "@noble/hashes": "1.3.0",
+        "@noble/secp256k1": "1.7.0",
+        "@scure/base": "1.1.1",
+        "@solana/spl-token": "0.3.8",
+        "@wormhole-foundation/sdk": "1.0.3",
+        "assert": "2.0.0",
+        "async-mutex": "0.5.0",
+        "async-retry": "1.3.1",
+        "axios": "0.19.2",
+        "borsh": "0.4.0",
+        "cross-fetch": "4.0.0",
+        "file-type": "16.5.3",
+        "form-data": "3.0.0",
+        "hashids": "2.2.10",
+        "isomorphic-ws": "5.0.0",
+        "micro-aes-gcm": "0.4.0",
+        "multiformats": "13.3.1",
+        "node-abort-controller": "3.1.1",
+        "node-localstorage": "1.3.1",
+        "semver": "6.3.0",
+        "snakecase-keys": "5.4.5",
+        "tus-js-client": "4.3.1",
+        "type-fest": "4.26.1",
+        "ulid": "2.3.0",
+        "url": "0.11.1",
+        "viem": "2.21.21",
+        "xmlhttprequest": "1.8.0",
+        "zod": "3.21.4"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.24.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": ">=1.0.0",
+        "@solana/web3.js": "^1.95.8",
+        "expo-web-browser": ">=14.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        },
+        "expo-web-browser": {
+          "optional": true
+        }
+      }
     },
     "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy": {
       "name": "@audius/sdk",
@@ -179,6 +246,68 @@
         "bs58": "^4.0.0",
         "text-encoding-utf-8": "^1.0.2"
       }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk/node_modules/@audius/fixed-decimal": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.2.1.tgz",
+      "integrity": "sha512-cfE5pFS7gJkykxtMukMsJX68Mh8498XHrWf1MAqq/xSflquQwPZJRlQkaaeyTurV03qyG6QKCTjEVfqumoPLeA==",
+      "license": "Apache-2.0"
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk/node_modules/@audius/spl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@audius/spl/-/spl-2.1.0.tgz",
+      "integrity": "sha512-5L9RmH6nVMZgh6Xaqo5pliiznSWKx0k5c4Q5rSQ0BSnmylrIsXMch+NtEvk3+w9yKXiJy5krFH0uqaGXlEY4Uw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@coral-xyz/anchor": "0.29.0",
+        "@noble/hashes": "1.4.0",
+        "@solana/buffer-layout": "4.0.1",
+        "@solana/buffer-layout-utils": "0.2.0",
+        "@solana/spl-token": "0.3.8",
+        "bs58": "6.0.0"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.95.8"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk/node_modules/@audius/spl/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk/node_modules/@noble/hashes": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+      "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk/node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@audius/sdk/node_modules/multiformats": {
+      "version": "13.3.1",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
+      "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==",
+      "license": "Apache-2.0 OR MIT"
     },
     "apps/anti-abuse-oracle/node_modules/@audius/spl": {
       "version": "1.0.1",
@@ -412,6 +541,33 @@
         "@ethersproject/strings": "^5.4.0"
       }
     },
+    "apps/anti-abuse-oracle/node_modules/@noble/curves": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+      "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.5.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "apps/anti-abuse-oracle/node_modules/@noble/hashes": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -446,6 +602,12 @@
       "dependencies": {
         "follow-redirects": "1.5.10"
       }
+    },
+    "apps/anti-abuse-oracle/node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
     },
     "apps/anti-abuse-oracle/node_modules/borsh": {
       "version": "0.4.0",
@@ -707,7 +869,7 @@
     },
     "apps/anti-abuse-oracle/node_modules/typescript": {
       "version": "5.0.4",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -715,6 +877,70 @@
       },
       "engines": {
         "node": ">=12.20"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/viem": {
+      "version": "2.21.21",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
+      "integrity": "sha512-KJPqpAXy8kyZQICx1nURUXqd8aABP9RweAZhfp27MzMPsAAxP450cWPlEffEAUrvsyyj5edVbIcHESE8DYVzFA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.11.0",
+        "@noble/curves": "1.6.0",
+        "@noble/hashes": "1.5.0",
+        "@scure/bip32": "1.5.0",
+        "@scure/bip39": "1.4.0",
+        "abitype": "1.0.6",
+        "isows": "1.0.6",
+        "webauthn-p256": "0.0.10",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/viem/node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "apps/anti-abuse-oracle/node_modules/viem/node_modules/abitype": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
+      "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "apps/app-template": {
@@ -5265,6 +5491,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.1.0.tgz",
       "integrity": "sha512-g2ltIqqd8ziIIBzzBIiYlmEjdEfWMKz0pJHlBj53JiCL8blqUD/ltBFwSGZk3vpOBqamBIFmRZSjdSzMDIsZ6A==",
+      "dev": true,
       "dependencies": {
         "@audius/eth": "1.0.0",
         "@audius/fixed-decimal": "0.2.1",
@@ -5948,12 +6175,14 @@
     "node_modules/@audius/sdk/node_modules/@audius/eth": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
-      "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
+      "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
+      "dev": true
     },
     "node_modules/@audius/sdk/node_modules/@noble/curves": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
       "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.5.0"
       },
@@ -5968,6 +6197,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -5979,6 +6209,7 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5988,6 +6219,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
       "deprecated": "Critical security vulnerability fixed in v0.21.1. For more information, see https://github.com/axios/axios/pull/3410",
+      "dev": true,
       "dependencies": {
         "follow-redirects": "1.5.10"
       }
@@ -5996,6 +6228,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
       "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+      "dev": true,
       "dependencies": {
         "@types/bn.js": "^4.11.5",
         "bn.js": "^5.0.0",
@@ -6007,6 +6240,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
       "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+      "dev": true,
       "dependencies": {
         "node-fetch": "^2.6.12"
       }
@@ -6015,6 +6249,7 @@
       "version": "2.21.21",
       "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
       "integrity": "sha512-KJPqpAXy8kyZQICx1nURUXqd8aABP9RweAZhfp27MzMPsAAxP450cWPlEffEAUrvsyyj5edVbIcHESE8DYVzFA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6045,6 +6280,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
       "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "dev": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6056,6 +6292,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
       "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/wevm"
       },
@@ -42765,6 +43002,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.1.0.tgz",
       "integrity": "sha512-g2ltIqqd8ziIIBzzBIiYlmEjdEfWMKz0pJHlBj53JiCL8blqUD/ltBFwSGZk3vpOBqamBIFmRZSjdSzMDIsZ6A==",
+      "dev": true,
       "requires": {
         "@audius/eth": "1.0.0",
         "@audius/fixed-decimal": "0.2.1",
@@ -42807,12 +43045,14 @@
         "@audius/eth": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
-          "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
+          "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
+          "dev": true
         },
         "@noble/curves": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
           "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+          "dev": true,
           "requires": {
             "@noble/hashes": "1.5.0"
           },
@@ -42820,7 +43060,8 @@
             "@noble/hashes": {
               "version": "1.5.0",
               "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
+              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+              "dev": true
             }
           }
         },
@@ -42828,6 +43069,7 @@
           "version": "4.11.6",
           "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+          "dev": true,
           "requires": {
             "@types/node": "*"
           }
@@ -42836,6 +43078,7 @@
           "version": "0.19.2",
           "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
           "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "dev": true,
           "requires": {
             "follow-redirects": "1.5.10"
           }
@@ -42844,6 +43087,7 @@
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.4.0.tgz",
           "integrity": "sha512-aX6qtLya3K0AkT66CmYWCCDr77qsE9arV05OmdFpmat9qu8Pg9J5tBUPDztAW5fNh/d/MyVG/OYziP52Ndzx1g==",
+          "dev": true,
           "requires": {
             "@types/bn.js": "^4.11.5",
             "bn.js": "^5.0.0",
@@ -42855,6 +43099,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
           "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
+          "dev": true,
           "requires": {
             "node-fetch": "^2.6.12"
           }
@@ -42863,6 +43108,7 @@
           "version": "2.21.21",
           "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
           "integrity": "sha512-KJPqpAXy8kyZQICx1nURUXqd8aABP9RweAZhfp27MzMPsAAxP450cWPlEffEAUrvsyyj5edVbIcHESE8DYVzFA==",
+          "dev": true,
           "requires": {
             "@adraffy/ens-normalize": "1.11.0",
             "@noble/curves": "1.6.0",
@@ -42878,12 +43124,14 @@
             "@noble/hashes": {
               "version": "1.5.0",
               "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
-              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
+              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+              "dev": true
             },
             "abitype": {
               "version": "1.0.6",
               "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
               "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+              "dev": true,
               "requires": {}
             }
           }
@@ -49334,7 +49582,7 @@
     "@pedalboard/anti-abuse-oracle": {
       "version": "file:apps/anti-abuse-oracle",
       "requires": {
-        "@audius/sdk": "15.1.0",
+        "@audius/sdk": "^15.3.1",
         "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
         "@hono/node-server": "1.19.1",
         "@pedalboard/basekit": "*",
@@ -49364,10 +49612,102 @@
         "typescript": "5.0.4"
       },
       "dependencies": {
+        "@audius/eth": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
+          "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
+        },
         "@audius/fixed-decimal": {
           "version": "0.1.0",
           "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.1.0.tgz",
           "integrity": "sha512-iwafMiqtRuf3eaE+j/EDqAkRRxtWB8g/QgqukUbw2D1KiYiSZblakWs7Q+tdnTBKml1oB0nrGHSKvVPEBxbSRQ=="
+        },
+        "@audius/sdk": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.3.1.tgz",
+          "integrity": "sha512-cUGQXdUaaqd2uGm6Xa/vgHEKIenJsA/HWb30SzIv5dpILjsBK79ZM7+dBoT84TV0CsNJLuMn+wt1pbgcrOWtiQ==",
+          "requires": {
+            "@audius/eth": "1.0.0",
+            "@audius/fixed-decimal": "0.2.1",
+            "@audius/hedgehog": "3.0.0-alpha.1",
+            "@audius/spl": "2.1.0",
+            "@babel/runtime": "7.18.3",
+            "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
+            "@noble/hashes": "1.3.0",
+            "@noble/secp256k1": "1.7.0",
+            "@rollup/rollup-linux-x64-gnu": "4.24.0",
+            "@scure/base": "1.1.1",
+            "@solana/spl-token": "0.3.8",
+            "@wormhole-foundation/sdk": "1.0.3",
+            "assert": "2.0.0",
+            "async-mutex": "0.5.0",
+            "async-retry": "1.3.1",
+            "axios": "0.19.2",
+            "borsh": "0.4.0",
+            "cross-fetch": "4.0.0",
+            "file-type": "16.5.3",
+            "form-data": "3.0.0",
+            "hashids": "2.2.10",
+            "isomorphic-ws": "5.0.0",
+            "micro-aes-gcm": "0.4.0",
+            "multiformats": "13.3.1",
+            "node-abort-controller": "3.1.1",
+            "node-localstorage": "1.3.1",
+            "semver": "6.3.0",
+            "snakecase-keys": "5.4.5",
+            "tus-js-client": "4.3.1",
+            "type-fest": "4.26.1",
+            "ulid": "2.3.0",
+            "url": "0.11.1",
+            "viem": "2.21.21",
+            "xmlhttprequest": "1.8.0",
+            "zod": "3.21.4"
+          },
+          "dependencies": {
+            "@audius/fixed-decimal": {
+              "version": "0.2.1",
+              "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.2.1.tgz",
+              "integrity": "sha512-cfE5pFS7gJkykxtMukMsJX68Mh8498XHrWf1MAqq/xSflquQwPZJRlQkaaeyTurV03qyG6QKCTjEVfqumoPLeA=="
+            },
+            "@audius/spl": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/@audius/spl/-/spl-2.1.0.tgz",
+              "integrity": "sha512-5L9RmH6nVMZgh6Xaqo5pliiznSWKx0k5c4Q5rSQ0BSnmylrIsXMch+NtEvk3+w9yKXiJy5krFH0uqaGXlEY4Uw==",
+              "requires": {
+                "@coral-xyz/anchor": "0.29.0",
+                "@noble/hashes": "1.4.0",
+                "@solana/buffer-layout": "4.0.1",
+                "@solana/buffer-layout-utils": "0.2.0",
+                "@solana/spl-token": "0.3.8",
+                "bs58": "6.0.0"
+              },
+              "dependencies": {
+                "@noble/hashes": {
+                  "version": "1.4.0",
+                  "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+                  "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
+                }
+              }
+            },
+            "@noble/hashes": {
+              "version": "1.3.0",
+              "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.0.tgz",
+              "integrity": "sha512-ilHEACi9DwqJB0pw7kv+Apvh50jiiSyR/cQ3y4W7lOR5mhvn/50FLUfsnfJz0BDZtl/RR16kXvptiv6q1msYZg=="
+            },
+            "bs58": {
+              "version": "6.0.0",
+              "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+              "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+              "requires": {
+                "base-x": "^5.0.0"
+              }
+            },
+            "multiformats": {
+              "version": "13.3.1",
+              "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.3.1.tgz",
+              "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g=="
+            }
+          }
         },
         "@audius/sdk-legacy": {
           "version": "npm:@audius/sdk@5.0.0",
@@ -49619,6 +49959,21 @@
             "@ethersproject/strings": "^5.4.0"
           }
         },
+        "@noble/curves": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
+          "integrity": "sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==",
+          "requires": {
+            "@noble/hashes": "1.5.0"
+          },
+          "dependencies": {
+            "@noble/hashes": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
+            }
+          }
+        },
         "@noble/hashes": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
@@ -49643,6 +49998,11 @@
           "requires": {
             "follow-redirects": "1.5.10"
           }
+        },
+        "base-x": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+          "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg=="
         },
         "borsh": {
           "version": "0.4.0",
@@ -49856,7 +50216,36 @@
         },
         "typescript": {
           "version": "5.0.4",
-          "dev": true
+          "devOptional": true
+        },
+        "viem": {
+          "version": "2.21.21",
+          "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.21.tgz",
+          "integrity": "sha512-KJPqpAXy8kyZQICx1nURUXqd8aABP9RweAZhfp27MzMPsAAxP450cWPlEffEAUrvsyyj5edVbIcHESE8DYVzFA==",
+          "requires": {
+            "@adraffy/ens-normalize": "1.11.0",
+            "@noble/curves": "1.6.0",
+            "@noble/hashes": "1.5.0",
+            "@scure/bip32": "1.5.0",
+            "@scure/bip39": "1.4.0",
+            "abitype": "1.0.6",
+            "isows": "1.0.6",
+            "webauthn-p256": "0.0.10",
+            "ws": "8.18.0"
+          },
+          "dependencies": {
+            "@noble/hashes": {
+              "version": "1.5.0",
+              "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+              "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
+            },
+            "abitype": {
+              "version": "1.0.6",
+              "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.6.tgz",
+              "integrity": "sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==",
+              "requires": {}
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- Bump `@audius/sdk` in `apps/anti-abuse-oracle` from `15.1.0` → `^15.3.1` to pick up the fix for the lodash ESM crash.
- `@audius/sdk-legacy` (the `npm:@audius/sdk@5.0.0` alias) is intentionally left pinned.
- Lockfile updated via `npm install`.

The `edge.yml` CI will auto-trigger on merge and rebuild the Docker image.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, verify `edge.yml` builds and publishes the aao image
- [ ] Confirm the lodash ESM crash no longer reproduces in the deployed service

🤖 Generated with [Claude Code](https://claude.com/claude-code)