### PR TITLE
anti-abuse-oracle: rip out @audius/sdk-legacy

### DIFF
--- a/apps/anti-abuse-oracle/package.json
+++ b/apps/anti-abuse-oracle/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@audius/sdk": "^15.3.1",
-    "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
+    "@audius/spl": "2.1.0",
     "@hono/node-server": "1.19.1",
     "@pedalboard/basekit": "*",
     "@pedalboard/logger": "*",
@@ -27,8 +27,10 @@
     "dotenv": "16.6.1",
     "envalid": "8.0.0",
     "hono": "4.9.5",
+    "keccak256": "1.0.6",
     "pino": "9.0.0",
-    "postgres": "3.4.7"
+    "postgres": "3.4.7",
+    "secp256k1": "5.0.0"
   },
   "devDependencies": {
     "@types/bn.js": "5.2.0",

--- a/apps/anti-abuse-oracle/src/server.tsx
+++ b/apps/anti-abuse-oracle/src/server.tsx
@@ -16,12 +16,26 @@ import {
 } from './actionLog'
 import { logger } from 'hono/logger'
 import { config } from './config'
-import { HashId } from '@audius/sdk'
-import { SolanaUtils, Utils } from '@audius/sdk-legacy'
+import { HashId, Id } from '@audius/sdk'
+import { RewardManagerProgram } from '@audius/spl'
 import bn from 'bn.js'
+import keccak256 from 'keccak256'
+import * as secp256k1 from 'secp256k1'
 import { useEmail, userFingerprints } from './identity'
 import { cors } from 'hono/cors'
 import { getAudiusSdk } from './sdk'
+
+const WAUDIO_DECIMALS = 8
+
+const signBytes = (bytes: Buffer, ethPrivateKey: string) => {
+  const msgHash = keccak256(bytes)
+  const privateKey = Buffer.from(ethPrivateKey, 'hex')
+  const { signature, recid } = secp256k1.ecdsaSign(
+    Uint8Array.from(msgHash),
+    privateKey
+  )
+  return { signature: Buffer.from(signature), recoveryId: recid }
+}
 
 const CONTENT_NODE = 'https://creatornode2.audius.co'
 const FRONTEND = 'https://audius.co'
@@ -214,18 +228,15 @@ app.post('/attestation/:handle', async (c) => {
   }
 
   try {
-    const bnAmount = SolanaUtils.uiAudioToBNWaudio(amount)
-    const identifier = SolanaUtils.constructTransferId(
-      challengeId,
-      challengeSpecifier
-    )
-    const toSignStr = SolanaUtils.constructAttestation(
-      user.wallet,
-      bnAmount,
-      identifier
-    )
-    const { signature, recoveryId } = SolanaUtils.signBytes(
-      Buffer.from(toSignStr),
+    const amountWaudio = BigInt(Math.round(amount * 10 ** WAUDIO_DECIMALS))
+    const disbursementId = `${challengeId}:${challengeSpecifier}`
+    const messageBytes = RewardManagerProgram.encodeAttestation({
+      recipientEthAddress: user.wallet,
+      amount: amountWaudio,
+      disbursementId
+    })
+    const { signature, recoveryId } = signBytes(
+      messageBytes,
       config.privateSignerAddress
     )
     const result = new bn(Uint8Array.of(...signature, recoveryId))
@@ -396,7 +407,7 @@ app.get('/attestation/ui/user', async (c) => {
                 </a>
               </div>
               <div>{user.id}</div>
-              <div>{Utils.encodeHashId(user.id)}</div>
+              <div>{Id.parse(user.id)}</div>
               {user.isVerified && <div class='badge'>Verified</div>}
             </div>
             <div class='flex gap-2 mt-2 items-center'>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
       "version": "0.0.30",
       "dependencies": {
         "@audius/sdk": "^15.3.1",
-        "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
+        "@audius/spl": "2.1.0",
         "@hono/node-server": "1.19.1",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
@@ -37,8 +37,10 @@
         "dotenv": "16.6.1",
         "envalid": "8.0.0",
         "hono": "4.9.5",
+        "keccak256": "1.0.6",
         "pino": "9.0.0",
-        "postgres": "3.4.7"
+        "postgres": "3.4.7",
+        "secp256k1": "5.0.0"
       },
       "devDependencies": {
         "@types/bn.js": "5.2.0",
@@ -61,12 +63,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
       "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
-      "license": "Apache-2.0"
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/fixed-decimal": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.1.0.tgz",
-      "integrity": "sha512-iwafMiqtRuf3eaE+j/EDqAkRRxtWB8g/QgqukUbw2D1KiYiSZblakWs7Q+tdnTBKml1oB0nrGHSKvVPEBxbSRQ==",
       "license": "Apache-2.0"
     },
     "apps/anti-abuse-oracle/node_modules/@audius/sdk": {
@@ -128,123 +124,6 @@
         "expo-web-browser": {
           "optional": true
         }
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy": {
-      "name": "@audius/sdk",
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-5.0.0.tgz",
-      "integrity": "sha512-W8nBFdNIADbwU2YNIDXJL44Qx+wf7RtNZ47Ttv/tI7p1+hLMPpJU8gq7YXK5gZvx9NGgQMWSVAQQ1nCra7HbRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@audius/fixed-decimal": "0.1.0",
-        "@audius/hedgehog": "3.0.0-alpha.1",
-        "@audius/spl": "1.0.1",
-        "@babel/core": "^7.23.7",
-        "@babel/plugin-proposal-class-static-block": "7.21.0",
-        "@babel/runtime": "7.18.3",
-        "@certusone/wormhole-sdk": "0.1.1",
-        "@ethersproject/solidity": "5.0.5",
-        "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
-        "@noble/hashes": "^1.3.0",
-        "@noble/secp256k1": "1.7.0",
-        "@project-serum/anchor": "0.24.1",
-        "@scure/base": "1.1.1",
-        "@solana/spl-token": "0.3.8",
-        "@solana/web3.js": "1.93.4",
-        "abi-decoder": "2.4.0",
-        "ajv": "6.12.2",
-        "assert": "2.0.0",
-        "async-retry": "1.3.1",
-        "axios": "0.19.2",
-        "bn.js": "5.2.1",
-        "borsh": "0.4.0",
-        "browser-or-node": "^2.1.1",
-        "bs58": "4.0.1",
-        "cipher-base": "1.0.4",
-        "crc-32": "1.2.2",
-        "cross-fetch": "4.0.0",
-        "elliptic": "6.5.4",
-        "esm": "3.2.25",
-        "eth-sig-util": "2.5.4",
-        "ethereumjs-tx": "2.1.2",
-        "ethereumjs-util": "7.1.4",
-        "ethereumjs-wallet": "1.0.2",
-        "ethers": "5.4.7",
-        "file-type": "16.5.3",
-        "form-data": "3.0.0",
-        "hashids": "2.2.10",
-        "interface-blockstore": "2.0.3",
-        "interface-store": "2.0.2",
-        "ipfs-unixfs-importer": "9.0.6",
-        "isomorphic-ws": "5.0.0",
-        "jsonschema": "1.2.6",
-        "keccak256": "1.0.2",
-        "lodash": "4.17.21",
-        "micro-aes-gcm": "0.4.0",
-        "multiformats": "9.9.0",
-        "node-abort-controller": "3.1.1",
-        "node-localstorage": "1.3.1",
-        "proper-url-join": "2.1.1",
-        "rollup-plugin-shim": "1.0.0",
-        "safe-buffer": "5.2.1",
-        "secp256k1": "4.0.2",
-        "semver": "6.3.0",
-        "snakecase-keys": "5.4.5",
-        "stream-browserify": "3.0.0",
-        "strtok3": "6.3.0",
-        "token-types": "4.2.1",
-        "ulid": "2.3.0",
-        "url": "0.11.1",
-        "web3": "1.8.2",
-        "xmlhttprequest": "1.8.0",
-        "zod": "3.21.4"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy/node_modules/@solana/web3.js": {
-      "version": "1.93.4",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
-      "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "@solana/buffer-layout": "^4.0.1",
-        "agentkeepalive": "^4.5.0",
-        "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.2.1",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.0",
-        "node-fetch": "^2.7.0",
-        "rpc-websockets": "^9.0.2",
-        "superstruct": "^1.0.4"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy/node_modules/@solana/web3.js/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/sdk-legacy/node_modules/@solana/web3.js/node_modules/borsh": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
       }
     },
     "apps/anti-abuse-oracle/node_modules/@audius/sdk/node_modules/@audius/fixed-decimal": {
@@ -309,238 +188,6 @@
       "integrity": "sha512-QxowxTNwJ3r5RMctoGA5p13w5RbRT2QDkoM+yFlqfLiioBp78nhDjnRLvmSBI9+KAqN4VdgOVWM9c0CHd86m3g==",
       "license": "Apache-2.0 OR MIT"
     },
-    "apps/anti-abuse-oracle/node_modules/@audius/spl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@audius/spl/-/spl-1.0.1.tgz",
-      "integrity": "sha512-vhW1UEzQHPeMuxuYGIiJJoD+a8l7Ui7Fqsne5R1LcFXJek5dlKTAvILY9qWSqWRFeAIVY8Uo/dKmmJ1Y2OteIA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@coral-xyz/anchor": "0.29.0",
-        "@noble/hashes": "1.4.0",
-        "@solana/buffer-layout": "4.0.1",
-        "@solana/buffer-layout-utils": "0.2.0",
-        "@solana/spl-token": "0.3.8",
-        "@solana/web3.js": "1.93.4"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/spl/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/spl/node_modules/@solana/web3.js": {
-      "version": "1.93.4",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
-      "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.24.7",
-        "@noble/curves": "^1.4.0",
-        "@noble/hashes": "^1.4.0",
-        "@solana/buffer-layout": "^4.0.1",
-        "agentkeepalive": "^4.5.0",
-        "bigint-buffer": "^1.1.5",
-        "bn.js": "^5.2.1",
-        "borsh": "^0.7.0",
-        "bs58": "^4.0.1",
-        "buffer": "6.0.3",
-        "fast-stable-stringify": "^1.0.0",
-        "jayson": "^4.1.0",
-        "node-fetch": "^2.7.0",
-        "rpc-websockets": "^9.0.2",
-        "superstruct": "^1.0.4"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@audius/spl/node_modules/borsh": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/abstract-provider": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
-      "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/networks": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/transactions": "^5.4.0",
-        "@ethersproject/web": "^5.4.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/bignumber": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
-      "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "bn.js": "^4.11.9"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/bignumber/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/bytes": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-      "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/logger": "^5.4.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/logger": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
-      "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT"
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/networks": {
-      "version": "5.4.2",
-      "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
-      "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/logger": "^5.4.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/properties": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
-      "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/logger": "^5.4.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/transactions": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-      "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/address": "^5.4.0",
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/constants": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/rlp": "^5.4.0",
-        "@ethersproject/signing-key": "^5.4.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@ethersproject/web": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-      "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/base64": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/logger": "^5.4.0",
-        "@ethersproject/properties": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
-      }
-    },
     "apps/anti-abuse-oracle/node_modules/@noble/curves": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
@@ -563,18 +210,6 @@
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -649,154 +284,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "apps/anti-abuse-oracle/node_modules/elliptic": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.9",
-        "brorand": "^1.1.0",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.1",
-        "inherits": "^2.0.4",
-        "minimalistic-assert": "^1.0.1",
-        "minimalistic-crypto-utils": "^1.0.1"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/elliptic/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "apps/anti-abuse-oracle/node_modules/eth-sig-util": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
-      "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
-      "deprecated": "Deprecated in favor of '@metamask/eth-sig-util'",
-      "license": "ISC",
-      "dependencies": {
-        "ethereumjs-abi": "0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/eth-sig-util/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "apps/anti-abuse-oracle/node_modules/eth-sig-util/node_modules/ethereumjs-util": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-      "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/ethers": {
-      "version": "5.4.7",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
-      "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/abi": "5.4.1",
-        "@ethersproject/abstract-provider": "5.4.1",
-        "@ethersproject/abstract-signer": "5.4.1",
-        "@ethersproject/address": "5.4.0",
-        "@ethersproject/base64": "5.4.0",
-        "@ethersproject/basex": "5.4.0",
-        "@ethersproject/bignumber": "5.4.2",
-        "@ethersproject/bytes": "5.4.0",
-        "@ethersproject/constants": "5.4.0",
-        "@ethersproject/contracts": "5.4.1",
-        "@ethersproject/hash": "5.4.0",
-        "@ethersproject/hdnode": "5.4.0",
-        "@ethersproject/json-wallets": "5.4.0",
-        "@ethersproject/keccak256": "5.4.0",
-        "@ethersproject/logger": "5.4.1",
-        "@ethersproject/networks": "5.4.2",
-        "@ethersproject/pbkdf2": "5.4.0",
-        "@ethersproject/properties": "5.4.1",
-        "@ethersproject/providers": "5.4.5",
-        "@ethersproject/random": "5.4.0",
-        "@ethersproject/rlp": "5.4.0",
-        "@ethersproject/sha2": "5.4.0",
-        "@ethersproject/signing-key": "5.4.0",
-        "@ethersproject/solidity": "5.4.0",
-        "@ethersproject/strings": "5.4.0",
-        "@ethersproject/transactions": "5.4.0",
-        "@ethersproject/units": "5.4.0",
-        "@ethersproject/wallet": "5.4.0",
-        "@ethersproject/web": "5.4.0",
-        "@ethersproject/wordlists": "5.4.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/ethers/node_modules/@ethersproject/solidity": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-      "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.4.0",
-        "@ethersproject/bytes": "^5.4.0",
-        "@ethersproject/keccak256": "^5.4.0",
-        "@ethersproject/sha2": "^5.4.0",
-        "@ethersproject/strings": "^5.4.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/keccak256": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.2.tgz",
-      "integrity": "sha512-f2EncSgmHmmQOkgxZ+/f2VaWTNkFL6f39VIrpoX+p8cEXJVyyCs/3h9GNz/ViHgwchxvv7oG5mjT2Tk4ZqInag==",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.8",
-        "keccak": "^3.0.1"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/keccak256/node_modules/bn.js": {
-      "version": "4.12.3",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-      "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g==",
-      "license": "MIT"
-    },
-    "apps/anti-abuse-oracle/node_modules/multiformats": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-      "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==",
-      "license": "(Apache-2.0 AND MIT)"
-    },
     "apps/anti-abuse-oracle/node_modules/pino": {
       "version": "9.0.0",
       "license": "MIT",
@@ -841,30 +328,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/secp256k1": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-      "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "elliptic": "^6.5.2",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "apps/anti-abuse-oracle/node_modules/superstruct": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-      "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "apps/anti-abuse-oracle/node_modules/typescript": {
@@ -49583,7 +49046,7 @@
       "version": "file:apps/anti-abuse-oracle",
       "requires": {
         "@audius/sdk": "^15.3.1",
-        "@audius/sdk-legacy": "npm:@audius/sdk@5.0.0",
+        "@audius/spl": "2.1.0",
         "@hono/node-server": "1.19.1",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
@@ -49604,9 +49067,11 @@
         "hono": "4.9.5",
         "jest": "26.6.3",
         "jest-presets": "*",
+        "keccak256": "1.0.6",
         "nodemon": "2.0.22",
         "pino": "9.0.0",
         "postgres": "3.4.7",
+        "secp256k1": "5.0.0",
         "supertest": "6.3.4",
         "tsconfig": "*",
         "typescript": "5.0.4"
@@ -49616,11 +49081,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
           "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
-        },
-        "@audius/fixed-decimal": {
-          "version": "0.1.0",
-          "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.1.0.tgz",
-          "integrity": "sha512-iwafMiqtRuf3eaE+j/EDqAkRRxtWB8g/QgqukUbw2D1KiYiSZblakWs7Q+tdnTBKml1oB0nrGHSKvVPEBxbSRQ=="
         },
         "@audius/sdk": {
           "version": "15.3.1",
@@ -49709,256 +49169,6 @@
             }
           }
         },
-        "@audius/sdk-legacy": {
-          "version": "npm:@audius/sdk@5.0.0",
-          "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-5.0.0.tgz",
-          "integrity": "sha512-W8nBFdNIADbwU2YNIDXJL44Qx+wf7RtNZ47Ttv/tI7p1+hLMPpJU8gq7YXK5gZvx9NGgQMWSVAQQ1nCra7HbRw==",
-          "requires": {
-            "@audius/fixed-decimal": "0.1.0",
-            "@audius/hedgehog": "3.0.0-alpha.1",
-            "@audius/spl": "1.0.1",
-            "@babel/core": "^7.23.7",
-            "@babel/plugin-proposal-class-static-block": "7.21.0",
-            "@babel/runtime": "7.18.3",
-            "@certusone/wormhole-sdk": "0.1.1",
-            "@ethersproject/solidity": "5.0.5",
-            "@improbable-eng/grpc-web-node-http-transport": "0.15.0",
-            "@noble/hashes": "^1.3.0",
-            "@noble/secp256k1": "1.7.0",
-            "@project-serum/anchor": "0.24.1",
-            "@scure/base": "1.1.1",
-            "@solana/spl-token": "0.3.8",
-            "@solana/web3.js": "1.93.4",
-            "abi-decoder": "2.4.0",
-            "ajv": "6.12.2",
-            "assert": "2.0.0",
-            "async-retry": "1.3.1",
-            "axios": "0.19.2",
-            "bn.js": "5.2.1",
-            "borsh": "0.4.0",
-            "browser-or-node": "^2.1.1",
-            "bs58": "4.0.1",
-            "cipher-base": "1.0.4",
-            "crc-32": "1.2.2",
-            "cross-fetch": "4.0.0",
-            "elliptic": "6.5.4",
-            "esm": "3.2.25",
-            "eth-sig-util": "2.5.4",
-            "ethereumjs-tx": "2.1.2",
-            "ethereumjs-util": "7.1.4",
-            "ethereumjs-wallet": "1.0.2",
-            "ethers": "5.4.7",
-            "file-type": "16.5.3",
-            "form-data": "3.0.0",
-            "hashids": "2.2.10",
-            "interface-blockstore": "2.0.3",
-            "interface-store": "2.0.2",
-            "ipfs-unixfs-importer": "9.0.6",
-            "isomorphic-ws": "5.0.0",
-            "jsonschema": "1.2.6",
-            "keccak256": "1.0.2",
-            "lodash": "4.17.21",
-            "micro-aes-gcm": "0.4.0",
-            "multiformats": "9.9.0",
-            "node-abort-controller": "3.1.1",
-            "node-localstorage": "1.3.1",
-            "proper-url-join": "2.1.1",
-            "rollup-plugin-shim": "1.0.0",
-            "safe-buffer": "5.2.1",
-            "secp256k1": "4.0.2",
-            "semver": "6.3.0",
-            "snakecase-keys": "5.4.5",
-            "stream-browserify": "3.0.0",
-            "strtok3": "6.3.0",
-            "token-types": "4.2.1",
-            "ulid": "2.3.0",
-            "url": "0.11.1",
-            "web3": "1.8.2",
-            "xmlhttprequest": "1.8.0",
-            "zod": "3.21.4"
-          },
-          "dependencies": {
-            "@solana/web3.js": {
-              "version": "1.93.4",
-              "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
-              "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
-              "requires": {
-                "@babel/runtime": "^7.24.7",
-                "@noble/curves": "^1.4.0",
-                "@noble/hashes": "^1.4.0",
-                "@solana/buffer-layout": "^4.0.1",
-                "agentkeepalive": "^4.5.0",
-                "bigint-buffer": "^1.1.5",
-                "bn.js": "^5.2.1",
-                "borsh": "^0.7.0",
-                "bs58": "^4.0.1",
-                "buffer": "6.0.3",
-                "fast-stable-stringify": "^1.0.0",
-                "jayson": "^4.1.0",
-                "node-fetch": "^2.7.0",
-                "rpc-websockets": "^9.0.2",
-                "superstruct": "^1.0.4"
-              },
-              "dependencies": {
-                "@babel/runtime": {
-                  "version": "7.29.2",
-                  "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-                  "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
-                },
-                "borsh": {
-                  "version": "0.7.0",
-                  "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-                  "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-                  "requires": {
-                    "bn.js": "^5.2.0",
-                    "bs58": "^4.0.0",
-                    "text-encoding-utf-8": "^1.0.2"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "@audius/spl": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/@audius/spl/-/spl-1.0.1.tgz",
-          "integrity": "sha512-vhW1UEzQHPeMuxuYGIiJJoD+a8l7Ui7Fqsne5R1LcFXJek5dlKTAvILY9qWSqWRFeAIVY8Uo/dKmmJ1Y2OteIA==",
-          "requires": {
-            "@coral-xyz/anchor": "0.29.0",
-            "@noble/hashes": "1.4.0",
-            "@solana/buffer-layout": "4.0.1",
-            "@solana/buffer-layout-utils": "0.2.0",
-            "@solana/spl-token": "0.3.8",
-            "@solana/web3.js": "1.93.4"
-          },
-          "dependencies": {
-            "@babel/runtime": {
-              "version": "7.29.2",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-              "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="
-            },
-            "@solana/web3.js": {
-              "version": "1.93.4",
-              "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.93.4.tgz",
-              "integrity": "sha512-6hHtSYmkUPwcm3eGeqBanMT3pDAhTprrm2IUoboSjNN4gKCBEkY9uIeS2TZKLpsGY+R6fDub5pRi+e4xFVv55w==",
-              "requires": {
-                "@babel/runtime": "^7.24.7",
-                "@noble/curves": "^1.4.0",
-                "@noble/hashes": "^1.4.0",
-                "@solana/buffer-layout": "^4.0.1",
-                "agentkeepalive": "^4.5.0",
-                "bigint-buffer": "^1.1.5",
-                "bn.js": "^5.2.1",
-                "borsh": "^0.7.0",
-                "bs58": "^4.0.1",
-                "buffer": "6.0.3",
-                "fast-stable-stringify": "^1.0.0",
-                "jayson": "^4.1.0",
-                "node-fetch": "^2.7.0",
-                "rpc-websockets": "^9.0.2",
-                "superstruct": "^1.0.4"
-              }
-            },
-            "borsh": {
-              "version": "0.7.0",
-              "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-              "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-              "requires": {
-                "bn.js": "^5.2.0",
-                "bs58": "^4.0.0",
-                "text-encoding-utf-8": "^1.0.2"
-              }
-            }
-          }
-        },
-        "@ethersproject/abstract-provider": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.4.1.tgz",
-          "integrity": "sha512-3EedfKI3LVpjSKgAxoUaI+gB27frKsxzm+r21w9G60Ugk+3wVLQwhi1LsEJAKNV7WoZc8CIpNrATlL1QFABjtQ==",
-          "requires": {
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/networks": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/transactions": "^5.4.0",
-            "@ethersproject/web": "^5.4.0"
-          }
-        },
-        "@ethersproject/bignumber": {
-          "version": "5.4.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.4.2.tgz",
-          "integrity": "sha512-oIBDhsKy5bs7j36JlaTzFgNPaZjiNDOXsdSgSpXRucUl+UA6L/1YLlFeI3cPAoodcenzF4nxNPV13pcy7XbWjA==",
-          "requires": {
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "bn.js": "^4.11.9"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.3",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-              "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
-            }
-          }
-        },
-        "@ethersproject/bytes": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.4.0.tgz",
-          "integrity": "sha512-H60ceqgTHbhzOj4uRc/83SCN9d+BSUnOkrr2intevqdtEMO1JFVZ1XL84OEZV+QjV36OaZYxtnt4lGmxcGsPfA==",
-          "requires": {
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/logger": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.1.tgz",
-          "integrity": "sha512-DZ+bRinnYLPw1yAC64oRl0QyVZj43QeHIhVKfD/+YwSz4wsv1pfwb5SOFjz+r710YEWzU6LrhuSjpSO+6PeE4A=="
-        },
-        "@ethersproject/networks": {
-          "version": "5.4.2",
-          "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.4.2.tgz",
-          "integrity": "sha512-eekOhvJyBnuibfJnhtK46b8HimBc5+4gqpvd1/H9LEl7Q7/qhsIhM81dI9Fcnjpk3jB1aTy6bj0hz3cifhNeYw==",
-          "requires": {
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/properties": {
-          "version": "5.4.1",
-          "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.4.1.tgz",
-          "integrity": "sha512-cyCGlF8wWlIZyizsj2PpbJ9I7rIlUAfnHYwy/T90pdkSn/NFTa5YWZx2wTJBe9V7dD65dcrrEMisCRUJiq6n3w==",
-          "requires": {
-            "@ethersproject/logger": "^5.4.0"
-          }
-        },
-        "@ethersproject/transactions": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.4.0.tgz",
-          "integrity": "sha512-s3EjZZt7xa4BkLknJZ98QGoIza94rVjaEed0rzZ/jB9WrIuu/1+tjvYCWzVrystXtDswy7TPBeIepyXwSYa4WQ==",
-          "requires": {
-            "@ethersproject/address": "^5.4.0",
-            "@ethersproject/bignumber": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/constants": "^5.4.0",
-            "@ethersproject/keccak256": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/rlp": "^5.4.0",
-            "@ethersproject/signing-key": "^5.4.0"
-          }
-        },
-        "@ethersproject/web": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.4.0.tgz",
-          "integrity": "sha512-1bUusGmcoRLYgMn6c1BLk1tOKUIFuTg8j+6N8lYlbMpDesnle+i3pGSagGNvwjaiLo4Y5gBibwctpPRmjrh4Og==",
-          "requires": {
-            "@ethersproject/base64": "^5.4.0",
-            "@ethersproject/bytes": "^5.4.0",
-            "@ethersproject/logger": "^5.4.0",
-            "@ethersproject/properties": "^5.4.0",
-            "@ethersproject/strings": "^5.4.0"
-          }
-        },
         "@noble/curves": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.6.0.tgz",
@@ -49973,11 +49183,6 @@
               "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA=="
             }
           }
-        },
-        "@noble/hashes": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-          "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="
         },
         "@types/node": {
           "version": "15.14.9"
@@ -50038,131 +49243,6 @@
           "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
           "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="
         },
-        "elliptic": {
-          "version": "6.5.4",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
-          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
-          "requires": {
-            "bn.js": "^4.11.9",
-            "brorand": "^1.1.0",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.1",
-            "inherits": "^2.0.4",
-            "minimalistic-assert": "^1.0.1",
-            "minimalistic-crypto-utils": "^1.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.3",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-              "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
-            }
-          }
-        },
-        "eth-sig-util": {
-          "version": "2.5.4",
-          "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.5.4.tgz",
-          "integrity": "sha512-aCMBwp8q/4wrW4QLsF/HYBOSA7TpLKmkVwP3pYQNkEEseW2Rr8Z5Uxc9/h6HX+OG3tuHo+2bINVSihIeBfym6A==",
-          "requires": {
-            "ethereumjs-abi": "0.6.8",
-            "ethereumjs-util": "^5.1.1",
-            "tweetnacl": "^1.0.3",
-            "tweetnacl-util": "^0.15.0"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.3",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-              "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
-            },
-            "ethereumjs-util": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.1.tgz",
-              "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
-              "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
-              }
-            }
-          }
-        },
-        "ethers": {
-          "version": "5.4.7",
-          "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.4.7.tgz",
-          "integrity": "sha512-iZc5p2nqfWK1sj8RabwsPM28cr37Bpq7ehTQ5rWExBr2Y09Sn1lDKZOED26n+TsZMye7Y6mIgQ/1cwpSD8XZew==",
-          "requires": {
-            "@ethersproject/abi": "5.4.1",
-            "@ethersproject/abstract-provider": "5.4.1",
-            "@ethersproject/abstract-signer": "5.4.1",
-            "@ethersproject/address": "5.4.0",
-            "@ethersproject/base64": "5.4.0",
-            "@ethersproject/basex": "5.4.0",
-            "@ethersproject/bignumber": "5.4.2",
-            "@ethersproject/bytes": "5.4.0",
-            "@ethersproject/constants": "5.4.0",
-            "@ethersproject/contracts": "5.4.1",
-            "@ethersproject/hash": "5.4.0",
-            "@ethersproject/hdnode": "5.4.0",
-            "@ethersproject/json-wallets": "5.4.0",
-            "@ethersproject/keccak256": "5.4.0",
-            "@ethersproject/logger": "5.4.1",
-            "@ethersproject/networks": "5.4.2",
-            "@ethersproject/pbkdf2": "5.4.0",
-            "@ethersproject/properties": "5.4.1",
-            "@ethersproject/providers": "5.4.5",
-            "@ethersproject/random": "5.4.0",
-            "@ethersproject/rlp": "5.4.0",
-            "@ethersproject/sha2": "5.4.0",
-            "@ethersproject/signing-key": "5.4.0",
-            "@ethersproject/solidity": "5.4.0",
-            "@ethersproject/strings": "5.4.0",
-            "@ethersproject/transactions": "5.4.0",
-            "@ethersproject/units": "5.4.0",
-            "@ethersproject/wallet": "5.4.0",
-            "@ethersproject/web": "5.4.0",
-            "@ethersproject/wordlists": "5.4.0"
-          },
-          "dependencies": {
-            "@ethersproject/solidity": {
-              "version": "5.4.0",
-              "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.4.0.tgz",
-              "integrity": "sha512-XFQTZ7wFSHOhHcV1DpcWj7VXECEiSrBuv7JErJvB9Uo+KfCdc3QtUZV+Vjh/AAaYgezUEKbCtE6Khjm44seevQ==",
-              "requires": {
-                "@ethersproject/bignumber": "^5.4.0",
-                "@ethersproject/bytes": "^5.4.0",
-                "@ethersproject/keccak256": "^5.4.0",
-                "@ethersproject/sha2": "^5.4.0",
-                "@ethersproject/strings": "^5.4.0"
-              }
-            }
-          }
-        },
-        "keccak256": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/keccak256/-/keccak256-1.0.2.tgz",
-          "integrity": "sha512-f2EncSgmHmmQOkgxZ+/f2VaWTNkFL6f39VIrpoX+p8cEXJVyyCs/3h9GNz/ViHgwchxvv7oG5mjT2Tk4ZqInag==",
-          "requires": {
-            "bn.js": "^4.11.8",
-            "keccak": "^3.0.1"
-          },
-          "dependencies": {
-            "bn.js": {
-              "version": "4.12.3",
-              "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.3.tgz",
-              "integrity": "sha512-fGTi3gxV/23FTYdAoUtLYp6qySe2KE3teyZitipKNRuVYcBkoP/bB3guXN/XVKUe9mxCHXnc9C4ocyz8OmgN0g=="
-            }
-          }
-        },
-        "multiformats": {
-          "version": "9.9.0",
-          "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-9.9.0.tgz",
-          "integrity": "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="
-        },
         "pino": {
           "version": "9.0.0",
           "requires": {
@@ -50198,21 +49278,6 @@
             "process": "^0.11.10",
             "string_decoder": "^1.3.0"
           }
-        },
-        "secp256k1": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.2.tgz",
-          "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
-          "requires": {
-            "elliptic": "^6.5.2",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
-          }
-        },
-        "superstruct": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-1.0.4.tgz",
-          "integrity": "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="
         },
         "typescript": {
           "version": "5.0.4",


### PR DESCRIPTION
## Summary

- Removes `@audius/sdk-legacy` from the AAO. The legacy SDK pulled in `@certusone/wormhole-sdk`, which requires `ethers` as an unsatisfied peer. After PR #34 fixed the lodash ESM crash, the AAO pod started crashing on `Cannot find module 'ethers'` instead — see the `CrashLoopBackOff` after deploy.
- Replaces the four `SolanaUtils` call sites with direct equivalents:
  - `uiAudioToBNWaudio` → `BigInt(Math.round(amount * 1e8))`
  - `constructTransferId` → template literal
  - `constructAttestation` → `RewardManagerProgram.encodeAttestation` from `@audius/spl@2.1.0` (already a transitive dep of the new SDK)
  - `signBytes` → 5-line local helper using `keccak256` + `secp256k1.ecdsaSign`, matching the pattern already used in `apps/solana-relay`
- Swaps `Utils.encodeHashId` for the new SDK's `Id` zod schema (inverse of `HashId`).

## Byte-compatibility

`@audius/spl`'s `RewardManagerProgram.encodeAttestation` produces byte-identical output to the legacy `SolanaUtils.constructAttestation`: same `addr ‖ '_' ‖ u64le ‖ '_' ‖ utf8(disbursementId) [‖ '_' ‖ oracle]` layout. The new layout has a nominal 83-byte span but `data.subarray(0, span)` trims to the actual written length, so disbursement IDs are not null-padded. On-chain Reward Manager will accept these unchanged.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` clean
- [x] Built `dist/server.js` loads through the entire require chain (previously crashed on `require('@certusone/wormhole-sdk')`); now only fails at the expected Postgres connection step
- [x] No `@certusone/*`, `ethers`, or `sdk-legacy` anywhere in the AAO node_modules resolution path after install
- [ ] Once merged: edge release builds, AAO pods restart cleanly (not CrashLoopBackOff), `/attestation/check` returns a signed result that the Reward Manager program accepts on-chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)