### PR TITLE
staking: migrate from discovery and fix prod runtime + build issues

### DIFF
--- a/apps/staking/package.json
+++ b/apps/staking/package.json
@@ -3,16 +3,18 @@
   "version": "0.0.2",
   "private": true,
   "scripts": {
-    "start": "npx tsx ./src/index.ts",
+    "build": "tsc",
+    "clean": "rm -rf dist",
     "dev": "npx tsx watch ./src/index.ts",
-    "test": "vitest",
-    "lint": "tsc --noEmit && eslint \"src/**/*.ts*\""
+    "lint": "tsc --noEmit && eslint \"src/**/*.ts*\"",
+    "start": "node ./dist/index.js",
+    "test": "vitest"
   },
   "jest": {
     "preset": "jest-presets/jest/node"
   },
   "dependencies": {
-    "@audius/eth": "0.1.0",
+    "@audius/eth": "1.0.0",
     "@audius/sdk": "10.0.0",
     "@pedalboard/basekit": "*",
     "@pedalboard/logger": "*",

--- a/apps/staking/src/index.ts
+++ b/apps/staking/src/index.ts
@@ -10,6 +10,8 @@ import dotenv from 'dotenv'
 
 dotenv.config()
 
+const PORT = 6000
+
 export type SharedData = {
   ethRpcEndpoint: string
   viemClient: PublicClient<HttpTransport, typeof mainnet>
@@ -27,7 +29,7 @@ const main = async () => {
       chain: mainnet,
       transport: http(process.env.eth_rpc_endpoint!)
     }),
-    port: process.env.port ? parseInt(process.env.port) : 6000
+    port: PORT
   }
   await new App<SharedData>({ appData: sharedData })
     .task(async (app: App<SharedData>) => {

--- a/apps/staking/src/routes/health.ts
+++ b/apps/staking/src/routes/health.ts
@@ -2,11 +2,11 @@ import { NextFunction, Request, Response } from 'express'
 import { App } from '@pedalboard/basekit'
 import { SharedData } from '..'
 
-export const health = (app: App<SharedData>) => async (
-  req: Request,
+export const health = (_app: App<SharedData>) => async (
+  _req: Request,
   res: Response,
   next: NextFunction
 ) => {
-  res.send({ status: 'up', port: app.viewAppData().port })
+  res.send({ status: 'ok' })
   next()
 }

--- a/apps/staking/src/routes/initRound.ts
+++ b/apps/staking/src/routes/initRound.ts
@@ -2,7 +2,6 @@ import { NextFunction, Request, Response } from 'express'
 import { App } from '@pedalboard/basekit'
 import { SharedData } from '..'
 import { ClaimsManager } from '@audius/eth'
-import { PublicClient } from 'viem'
 
 export const initRound = (app: App<SharedData>) => async (
   req: Request,
@@ -10,11 +9,26 @@ export const initRound = (app: App<SharedData>) => async (
   next: NextFunction
 ) => {
   const { viemClient } = app.viewAppData()
-  const claimsManager = new ClaimsManager(viemClient as PublicClient)
 
-  const latestBlock = Number((await viemClient.getBlock()).number)
-  const lastFundedBlockNumber = Number(await claimsManager.getLastFundedBlock())
-  const fundingRoundBlockDiff = Number(await claimsManager.getFundingRoundBlockDiff())
+  const [latestBlock, lastFundedBlockNumber, fundingRoundBlockDiff] =
+    await Promise.all([
+      viemClient.getBlock().then((b) => Number(b.number)),
+      viemClient
+        .readContract({
+          abi: ClaimsManager.abi,
+          address: ClaimsManager.address,
+          functionName: 'getLastFundedBlock'
+        })
+        .then(Number),
+      viemClient
+        .readContract({
+          abi: ClaimsManager.abi,
+          address: ClaimsManager.address,
+          functionName: 'getFundingRoundBlockDiff'
+        })
+        .then(Number)
+    ])
+
   const blockDiff = latestBlock - lastFundedBlockNumber
 
   if (lastFundedBlockNumber < latestBlock - 1.1 * fundingRoundBlockDiff) {
@@ -23,7 +37,7 @@ export const initRound = (app: App<SharedData>) => async (
       lastFundedBlockNumber,
       latestBlock,
       fundingRoundBlockDiff,
-      blockDiff,
+      blockDiff
     })
     next()
     return
@@ -34,8 +48,7 @@ export const initRound = (app: App<SharedData>) => async (
     lastFundedBlockNumber,
     latestBlock,
     fundingRoundBlockDiff,
-    blockDiff,
+    blockDiff
   })
   next()
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -3869,7 +3869,7 @@
       "name": "@pedalboard/staking",
       "version": "0.0.2",
       "dependencies": {
-        "@audius/eth": "0.1.0",
+        "@audius/eth": "1.0.0",
         "@audius/sdk": "10.0.0",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
@@ -3900,6 +3900,12 @@
         "typescript": "5.0.4",
         "vitest": "0.34.6"
       }
+    },
+    "apps/staking/node_modules/@audius/eth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
+      "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
+      "license": "Apache-2.0"
     },
     "apps/staking/node_modules/@audius/fixed-decimal": {
       "version": "0.2.0",
@@ -3954,6 +3960,15 @@
       },
       "peerDependencies": {
         "@solana/web3.js": "^1.95.8"
+      }
+    },
+    "apps/staking/node_modules/@audius/sdk/node_modules/@audius/eth": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-0.1.0.tgz",
+      "integrity": "sha512-RZ0K0xonhTVle237E2Mb1c+e4TEaqDQYCQPJtoPb6aNjcC3WU6i2i1ufIMz3sq7pGm1OSL7SzMxOE8QTrzU6cQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "viem": "2.21.21"
       }
     },
     "apps/staking/node_modules/@audius/sdk/node_modules/@babel/runtime": {
@@ -51855,7 +51870,7 @@
     "@pedalboard/staking": {
       "version": "file:apps/staking",
       "requires": {
-        "@audius/eth": "0.1.0",
+        "@audius/eth": "1.0.0",
         "@audius/sdk": "10.0.0",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
@@ -51885,6 +51900,11 @@
         "vitest": "0.34.6"
       },
       "dependencies": {
+        "@audius/eth": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
+          "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
+        },
         "@audius/fixed-decimal": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/@audius/fixed-decimal/-/fixed-decimal-0.2.0.tgz",
@@ -51932,6 +51952,14 @@
             "zod": "3.21.4"
           },
           "dependencies": {
+            "@audius/eth": {
+              "version": "0.1.0",
+              "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-0.1.0.tgz",
+              "integrity": "sha512-RZ0K0xonhTVle237E2Mb1c+e4TEaqDQYCQPJtoPb6aNjcC3WU6i2i1ufIMz3sq7pGm1OSL7SzMxOE8QTrzU6cQ==",
+              "requires": {
+                "viem": "2.21.21"
+              }
+            },
             "@babel/runtime": {
               "version": "7.18.3",
               "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",


### PR DESCRIPTION
## Summary
Migrates the staking service from `apps/packages/discovery-provider/plugins/pedalboard/apps/staking` to this repo at parity, and fixes a set of issues that would have prevented it from running correctly in prod:

- **`ClaimsManager` runtime bug** — `@audius/eth` 1.0.0 changed `ClaimsManager` from a class to a plain `{ abi, address }` object, so `new ClaimsManager(viemClient)` was a runtime crash. Bump the dep from 0.1.0 → 1.0.0 and rewrite `initRound` to use `viemClient.readContract({ abi, address, functionName })`. The three on-chain reads now run in parallel.
- **Build setup** — replace `start: npx tsx ./src/index.ts` with `build: tsc` + `start: node ./dist/index.js`, matching the `anti-abuse-oracle` pattern. The Dockerfile already runs `npm run build` during install, so the dev toolchain was being dragged into prod for no reason.
- **Health endpoint** — `GET /health` now returns the standard `{ status: 'ok' }` shape used by the other pedalboard services.
- **Port** — pin to `6000` (matches the nginx `/plugins/<service>/...` upstream) and drop the `process.env.port` fallback that no caller was setting.

## Git history
History preserved — `git log --follow apps/staking/src/index.ts` shows the original 3 commits from the discovery plugin (`Add staking plugin to replace other system checks`, `Update default staking health check plugin port`, `Add verified-notifications`).

## Source-of-truth comparison
Diffed against `apps/packages/discovery-provider/plugins/pedalboard/apps/staking` — only difference was that discovery uses a local `logger.ts` (because `@pedalboard/logger` inside discovery's monorepo only exports `log`). This repo's `@pedalboard/logger` already exports `createLogger`, so no local logger is needed.

## Paired PR
Pairs with **AudiusProject/apps#14375**, which adds the missing `env_file` and `environment:` blocks to the staking entry in `dev-tools/compose/docker-compose.pedalboard.prod.yml` so `solana_rpc_endpoint` and `eth_rpc_endpoint` actually reach the container. Until that lands, the service will boot but every Eth/Solana read will fail.

## Test plan
- [x] `npm run build` succeeds (`tsc` clean)
- [x] `npm run lint` clean (only pre-existing non-null assertion warnings unchanged by this PR)
- [ ] Deploy to a single discovery node and hit `/plugins/staking/health` — expect `{ status: 'ok' }`
- [ ] Hit `/plugins/staking/init-round` with valid `eth_rpc_endpoint` — expect 200 with `lastFundedBlockNumber`, `latestBlock`, `fundingRoundBlockDiff`, `blockDiff`
- [ ] Hit `/plugins/staking/balance?chain=eth&address=0x…` — expect 200 with formatted balance
- [ ] Hit `/plugins/staking/balance?chain=solana&address=…` — expect 200 with sol balance
- [ ] Verify `apps/packages/discovery-provider/plugins/pedalboard/apps/staking` can be removed in a follow-up after this deploys cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)