### PR TITLE
ci: run anti-abuse-oracle tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  anti-abuse-oracle:
+    name: anti-abuse-oracle
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test --workspace=@pedalboard/anti-abuse-oracle

--- a/apps/anti-abuse-oracle/package.json
+++ b/apps/anti-abuse-oracle/package.json
@@ -9,10 +9,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "tsc --noEmit && eslint \"src/**/*.ts*\"",
     "start": "node ./dist/server.js",
-    "test": "jest --detectOpenHandles"
-  },
-  "jest": {
-    "preset": "jest-presets/jest/node"
+    "test": "vitest run"
   },
   "dependencies": {
     "@audius/sdk": "^15.3.1",
@@ -34,18 +31,16 @@
   },
   "devDependencies": {
     "@types/bn.js": "5.2.0",
-    "@types/jest": "26.0.24",
     "@types/node": "15.14.9",
     "@types/supertest": "2.0.16",
     "esbuild": "0.14.38",
     "esbuild-register": "3.3.2",
     "eslint": "8.56.0",
     "eslint-config-custom-server": "*",
-    "jest": "26.6.3",
-    "jest-presets": "*",
     "nodemon": "2.0.22",
     "supertest": "6.3.4",
     "tsconfig": "*",
-    "typescript": "5.0.4"
+    "typescript": "5.0.4",
+    "vitest": "0.34.6"
   }
 }

--- a/apps/anti-abuse-oracle/src/__tests__/config.test.ts
+++ b/apps/anti-abuse-oracle/src/__tests__/config.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('dotenv', () => ({
+  default: { config: vi.fn(() => ({ parsed: {} })) },
+  config: vi.fn(() => ({ parsed: {} }))
+}))
+
+vi.mock('../logger', () => ({
+  logger: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn() }
+}))
+
+const AAO_ENV_KEYS = [
+  'audius_discprov_env',
+  'audius_discprov_url',
+  'audius_db_url',
+  'audius_redis_url',
+  'anti_abuse_oracle_server_host',
+  'anti_abuse_oracle_server_port',
+  'private_signer_address'
+] as const
+
+describe('config', () => {
+  const savedEnv: Record<string, string | undefined> = {}
+
+  beforeEach(() => {
+    for (const key of AAO_ENV_KEYS) {
+      savedEnv[key] = process.env[key]
+      delete process.env[key]
+    }
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    for (const key of AAO_ENV_KEYS) {
+      if (savedEnv[key] === undefined) {
+        delete process.env[key]
+      } else {
+        process.env[key] = savedEnv[key]
+      }
+    }
+  })
+
+  it('exposes defaults when no env vars are set', async () => {
+    const mod = await import('../config')
+    const cfg = mod.readConfig()
+    expect(cfg.environment).toBe('dev')
+    expect(cfg.discoveryDbConnectionString).toBe(
+      'postgresql+psycopg2://postgres:postgres@db:5432/discovery_provider_1'
+    )
+    expect(cfg.redisUrl).toBe('redis://audius-discovery-redis-1:6379/00')
+    expect(cfg.serverHost).toBe('0.0.0.0')
+    expect(cfg.serverPort).toBe(6003)
+    expect(cfg.privateSignerAddress).toBe('')
+  })
+
+  it('parses environment variables into Config', async () => {
+    process.env.audius_discprov_env = 'prod'
+    process.env.audius_db_url = 'postgres://test-db'
+    process.env.audius_redis_url = 'redis://test-redis'
+    process.env.anti_abuse_oracle_server_host = '127.0.0.1'
+    process.env.anti_abuse_oracle_server_port = '8080'
+    process.env.private_signer_address = 'abc123'
+
+    const mod = await import('../config')
+    const cfg = mod.readConfig()
+    expect(cfg.environment).toBe('prod')
+    expect(cfg.discoveryDbConnectionString).toBe('postgres://test-db')
+    expect(cfg.redisUrl).toBe('redis://test-redis')
+    expect(cfg.serverHost).toBe('127.0.0.1')
+    expect(cfg.serverPort).toBe(8080)
+    expect(cfg.privateSignerAddress).toBe('abc123')
+  })
+
+  it('coerces server port to a number', async () => {
+    process.env.anti_abuse_oracle_server_port = '4242'
+    const mod = await import('../config')
+    const cfg = mod.readConfig()
+    expect(cfg.serverPort).toBe(4242)
+    expect(typeof cfg.serverPort).toBe('number')
+  })
+
+  it('caches config after first call', async () => {
+    process.env.audius_discprov_env = 'dev'
+    const mod = await import('../config')
+    const first = mod.readConfig()
+    process.env.audius_discprov_env = 'prod'
+    const second = mod.readConfig()
+    expect(second).toBe(first)
+    expect(second.environment).toBe('dev')
+  })
+
+  it('exports Solana sysvar PublicKeys for clock and instructions', async () => {
+    const mod = await import('../config')
+    expect(mod.ClockProgram.toBase58()).toBe(
+      'SysvarC1ock11111111111111111111111111111111'
+    )
+    expect(mod.InstructionsProgram.toBase58()).toBe(
+      'Sysvar1nstructions1111111111111111111111111'
+    )
+  })
+
+  it('exports listens rate limit prefix constants', async () => {
+    const mod = await import('../config')
+    expect(mod.LISTENS_RATE_LIMIT_IP_PREFIX).toBe('listens-rate-limit-ip')
+    expect(mod.LISTENS_RATE_LIMIT_TRACK_PREFIX).toBe('listens-rate-limit-track')
+  })
+})

--- a/apps/anti-abuse-oracle/src/__tests__/identity.test.ts
+++ b/apps/anti-abuse-oracle/src/__tests__/identity.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+type SqlCall = {
+  strings: readonly string[]
+  values: unknown[]
+}
+
+const sqlCalls: SqlCall[] = []
+let nextResult: unknown[] = []
+
+const mockSqlFn = vi.fn(
+  (strings: readonly string[], ...values: unknown[]): Promise<unknown[]> => {
+    sqlCalls.push({ strings, values })
+    return Promise.resolve(nextResult)
+  }
+)
+
+type SqlTag = ((
+  strings: readonly string[],
+  ...values: unknown[]
+) => Promise<unknown[]>) & { unsafe: (raw: string) => string }
+
+const mockSql = mockSqlFn as unknown as SqlTag
+mockSql.unsafe = (raw: string) => raw
+
+vi.mock('postgres', () => ({
+  default: vi.fn(() => mockSql)
+}))
+
+describe('identity', () => {
+  beforeEach(() => {
+    sqlCalls.length = 0
+    nextResult = []
+    mockSqlFn.mockClear()
+  })
+
+  it('userFingerprints sorts userIds ascending and returns rows', async () => {
+    nextResult = [
+      { fingerprint: 'fp1', userCount: 3, userIds: [9, 1, 5] },
+      { fingerprint: 'fp2', userCount: 2, userIds: [7, 2] }
+    ]
+    const { userFingerprints } = await import('../identity')
+    const rows = await userFingerprints(42)
+    expect(rows).toEqual([
+      { fingerprint: 'fp1', userCount: 3, userIds: [1, 5, 9] },
+      { fingerprint: 'fp2', userCount: 2, userIds: [2, 7] }
+    ])
+
+    expect(sqlCalls).toHaveLength(1)
+    const call = sqlCalls[0]
+    expect(call.values).toEqual([42])
+    expect(call.strings.join('?')).toContain('"Fingerprints"')
+  })
+
+  it('useFingerprintDeviceCount returns maxUserCount from the first row', async () => {
+    nextResult = [{ maxUserCount: 7 }]
+    const { useFingerprintDeviceCount } = await import('../identity')
+    const count = await useFingerprintDeviceCount(99)
+    expect(count).toBe(7)
+    expect(sqlCalls[0].values).toEqual([99])
+  })
+
+  it('useFingerprintDeviceCount falls back to 0 when maxUserCount is null', async () => {
+    nextResult = [{ maxUserCount: null }]
+    const { useFingerprintDeviceCount } = await import('../identity')
+    expect(await useFingerprintDeviceCount(99)).toBe(0)
+  })
+
+  it('useEmailDeliverable looks up by wallet and returns isEmailDeliverable', async () => {
+    nextResult = [{ isEmailDeliverable: true }]
+    const { useEmailDeliverable } = await import('../identity')
+    expect(await useEmailDeliverable('0xWALLET')).toBe(true)
+    expect(sqlCalls[0].values).toEqual(['0xWALLET'])
+    expect(sqlCalls[0].strings.join('?')).toContain('"Users"')
+  })
+
+  it('useEmail looks up by blockchainUserId', async () => {
+    nextResult = [{ email: 'me@example.com' }]
+    const { useEmail } = await import('../identity')
+    expect(await useEmail(123)).toBe('me@example.com')
+    expect(sqlCalls[0].values).toEqual([123])
+    expect(sqlCalls[0].strings.join('?')).toContain('"blockchainUserId"')
+  })
+})

--- a/apps/anti-abuse-oracle/src/__tests__/sdk.test.ts
+++ b/apps/anti-abuse-oracle/src/__tests__/sdk.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+const sdkMock = vi.fn(() => ({ isFakeSdk: true }))
+
+vi.mock('@audius/sdk', () => ({
+  sdk: sdkMock
+}))
+
+const readConfigMock = vi.fn()
+
+vi.mock('../config', () => ({
+  readConfig: readConfigMock
+}))
+
+describe('sdk', () => {
+  beforeEach(() => {
+    sdkMock.mockClear()
+    readConfigMock.mockReset()
+    vi.resetModules()
+  })
+
+  it('initializes the SDK with the dev environment when config.environment is "dev"', async () => {
+    readConfigMock.mockReturnValue({ environment: 'dev' })
+    const { getAudiusSdk } = await import('../sdk')
+    const instance = getAudiusSdk()
+    expect(sdkMock).toHaveBeenCalledTimes(1)
+    expect(sdkMock).toHaveBeenCalledWith({
+      appName: 'anti-abuse-oracle',
+      environment: 'development'
+    })
+    expect(instance).toEqual({ isFakeSdk: true })
+  })
+
+  it('initializes the SDK with the production environment when config.environment is "prod"', async () => {
+    readConfigMock.mockReturnValue({ environment: 'prod' })
+    const { getAudiusSdk } = await import('../sdk')
+    getAudiusSdk()
+    expect(sdkMock).toHaveBeenCalledWith({
+      appName: 'anti-abuse-oracle',
+      environment: 'production'
+    })
+  })
+
+  it('caches the SDK instance across calls', async () => {
+    readConfigMock.mockReturnValue({ environment: 'dev' })
+    const { getAudiusSdk } = await import('../sdk')
+    const first = getAudiusSdk()
+    const second = getAudiusSdk()
+    expect(first).toBe(second)
+    expect(sdkMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/anti-abuse-oracle/src/__tests__/server.test.tsx
+++ b/apps/anti-abuse-oracle/src/__tests__/server.test.tsx
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('@hono/node-server', () => ({
+  serve: vi.fn()
+}))
+
+const sqlMock = vi.fn(
+  (_strings: readonly string[], ..._values: unknown[]) => Promise.resolve([])
+) as unknown as (
+  strings: readonly string[],
+  ...values: unknown[]
+) => Promise<unknown[]>
+
+const getUserNormalizedScoreMock = vi.fn()
+const getRecentClaimsMock = vi.fn()
+const getUserMock = vi.fn()
+const getUserScoreMock = vi.fn()
+const queryUsersMock = vi.fn()
+const recentTipsMock = vi.fn()
+const actionLogForUserMock = vi.fn()
+
+vi.mock('../actionLog', () => ({
+  sql: sqlMock,
+  getUserNormalizedScore: getUserNormalizedScoreMock,
+  getRecentClaims: getRecentClaimsMock,
+  getUser: getUserMock,
+  getUserScore: getUserScoreMock,
+  queryUsers: queryUsersMock,
+  recentTips: recentTipsMock,
+  actionLogForUser: actionLogForUserMock
+}))
+
+vi.mock('../identity', () => ({
+  useEmail: vi.fn(),
+  userFingerprints: vi.fn()
+}))
+
+vi.mock('../sdk', () => ({
+  getAudiusSdk: vi.fn(() => ({
+    users: {
+      getUserByHandle: vi.fn(async ({ handle }: { handle: string }) => {
+        if (handle === 'unknown') return { data: null }
+        return {
+          data: {
+            id: 'aE07A',
+            handle,
+            wallet: '0xabc',
+            isVerified: false
+          }
+        }
+      })
+    }
+  }))
+}))
+
+vi.mock('../config', () => ({
+  config: {
+    environment: 'dev',
+    discoveryDbConnectionString: '',
+    redisUrl: '',
+    serverHost: '0.0.0.0',
+    serverPort: 6003,
+    privateSignerAddress: '00'.repeat(32)
+  }
+}))
+
+vi.mock('@audius/sdk', () => ({
+  HashId: { parse: (s: string) => Number.parseInt(s, 36) || 1 },
+  Id: { parse: (n: number) => `HASH-${n}` }
+}))
+
+vi.mock('@audius/spl', () => ({
+  RewardManagerProgram: {
+    encodeAttestation: vi.fn(() => Buffer.from('encoded-attestation'))
+  }
+}))
+
+vi.mock('keccak256', () => ({
+  default: vi.fn(() => Buffer.alloc(32, 1))
+}))
+
+vi.mock('secp256k1', () => ({
+  ecdsaSign: vi.fn(() => ({ signature: new Uint8Array(64).fill(2), recid: 1 }))
+}))
+
+const setBasicAuthEnv = () => {
+  process.env.AAO_AUTH_USER = 'admin'
+  process.env.AAO_AUTH_PASSWORD = 'secret'
+}
+
+const basicAuthHeader = (user: string, pass: string) =>
+  'Basic ' + Buffer.from(`${user}:${pass}`).toString('base64')
+
+describe('server', () => {
+  beforeEach(() => {
+    const sqlAsMock = sqlMock as unknown as ReturnType<typeof vi.fn>
+    sqlAsMock.mockClear()
+    getUserNormalizedScoreMock.mockReset()
+    setBasicAuthEnv()
+  })
+
+  describe('GET /health_check', () => {
+    it('returns 200 with status ok', async () => {
+      const { app } = await import('../server')
+      const res = await app.request('/health_check')
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ status: 'ok' })
+    })
+  })
+
+  describe('GET /attestation/check', () => {
+    it('returns 400 when wallet query param is missing', async () => {
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/check')
+      expect(res.status).toBe(400)
+      expect(await res.json()).toEqual({ error: 'wallet is required' })
+    })
+
+    it('returns 404 when wallet is not found', async () => {
+      const sqlAsMock = sqlMock as unknown as ReturnType<typeof vi.fn>
+      sqlAsMock.mockImplementationOnce(() => Promise.resolve([]))
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/check?wallet=0xDEAD')
+      expect(res.status).toBe(404)
+      expect(await res.json()).toEqual({ error: 'wallet not found: 0xDEAD' })
+    })
+
+    it('returns "blocked" when overall score is negative', async () => {
+      const sqlAsMock = sqlMock as unknown as ReturnType<typeof vi.fn>
+      sqlAsMock.mockImplementationOnce(() =>
+        Promise.resolve([{ user_id: 1, wallet: '0xabc' }])
+      )
+      getUserNormalizedScoreMock.mockResolvedValueOnce({ overallScore: -50 })
+
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/check?wallet=0xABC')
+      expect(res.status).toBe(400)
+      expect(await res.json()).toEqual({ data: 'blocked' })
+      expect(getUserNormalizedScoreMock).toHaveBeenCalledWith(1, '0xabc')
+    })
+
+    it('returns "allowed" when overall score is non-negative', async () => {
+      const sqlAsMock = sqlMock as unknown as ReturnType<typeof vi.fn>
+      sqlAsMock.mockImplementationOnce(() =>
+        Promise.resolve([{ user_id: 2, wallet: '0xabc' }])
+      )
+      getUserNormalizedScoreMock.mockResolvedValueOnce({ overallScore: 42 })
+
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/check?wallet=0xABC')
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ data: 'allowed' })
+    })
+
+    it('lowercases the wallet before querying', async () => {
+      const sqlSpy = sqlMock as unknown as ReturnType<typeof vi.fn>
+      sqlSpy.mockImplementationOnce(
+        (_strings: readonly string[], ...values: unknown[]) => {
+          expect(values).toEqual(['0xabc'])
+          return Promise.resolve([{ user_id: 3, wallet: '0xabc' }])
+        }
+      )
+      getUserNormalizedScoreMock.mockResolvedValueOnce({ overallScore: 1 })
+
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/check?wallet=0xABC')
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('POST /attestation/block-user', () => {
+    it('requires basic auth', async () => {
+      const { app } = await import('../server')
+      const body = new URLSearchParams({ handle: 'spammer' })
+      const res = await app.request('/attestation/block-user', {
+        method: 'POST',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        body
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 400 when handle is missing in form body', async () => {
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/block-user', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          authorization: basicAuthHeader('admin', 'secret')
+        },
+        body: new URLSearchParams()
+      })
+      expect(res.status).toBe(400)
+      expect(await res.text()).toBe('Handle is required')
+    })
+
+    it('redirects after a successful block', async () => {
+      const sqlAsMock = sqlMock as unknown as ReturnType<typeof vi.fn>
+      sqlAsMock.mockImplementationOnce(() => Promise.resolve([]))
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/block-user', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded',
+          authorization: basicAuthHeader('admin', 'secret')
+        },
+        body: new URLSearchParams({ handle: 'Spammer' })
+      })
+      expect(res.status).toBe(302)
+      expect(res.headers.get('location')).toBe(
+        '/attestation/ui/user?q=Spammer'
+      )
+    })
+  })
+
+  describe('POST /attestation/:handle', () => {
+    it('returns 404 when the handle is not found in the SDK', async () => {
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/unknown', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          challengeId: 'dvl',
+          challengeSpecifier: 'spec',
+          amount: 1
+        })
+      })
+      expect(res.status).toBe(404)
+      expect(await res.json()).toEqual({ error: 'handle not found: unknown' })
+    })
+
+    it('denies a verified-only reward when the user is not verified', async () => {
+      const { app } = await import('../server')
+      const res = await app.request('/attestation/anyone', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          challengeId: 'u',
+          challengeSpecifier: 'spec',
+          amount: 1
+        })
+      })
+      expect(res.status).toBe(400)
+      expect(await res.json()).toEqual({ error: 'denied' })
+    })
+  })
+})

--- a/apps/anti-abuse-oracle/src/server.tsx
+++ b/apps/anti-abuse-oracle/src/server.tsx
@@ -102,7 +102,7 @@ async function ensureTableExists() {
 
 ensureTableExists()
 
-const app = new Hono()
+export const app = new Hono()
 
 app.use(logger())
 app.use('/attestation/*', cors())

--- a/apps/anti-abuse-oracle/vitest.config.ts
+++ b/apps/anti-abuse-oracle/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  esbuild: {
+    jsx: 'automatic',
+    jsxImportSource: 'hono/jsx'
+  },
+  test: {
+    globals: false,
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx']
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,19 +44,17 @@
       },
       "devDependencies": {
         "@types/bn.js": "5.2.0",
-        "@types/jest": "26.0.24",
         "@types/node": "15.14.9",
         "@types/supertest": "2.0.16",
         "esbuild": "0.14.38",
         "esbuild-register": "3.3.2",
         "eslint": "8.56.0",
         "eslint-config-custom-server": "*",
-        "jest": "26.6.3",
-        "jest-presets": "*",
         "nodemon": "2.0.22",
         "supertest": "6.3.4",
         "tsconfig": "*",
-        "typescript": "5.0.4"
+        "typescript": "5.0.4",
+        "vitest": "0.34.6"
       }
     },
     "apps/anti-abuse-oracle/node_modules/@audius/eth": {
@@ -49053,7 +49051,6 @@
         "@pedalboard/storage": "*",
         "@solana/web3.js": "1.98.4",
         "@types/bn.js": "5.2.0",
-        "@types/jest": "26.0.24",
         "@types/node": "15.14.9",
         "@types/supertest": "2.0.16",
         "bn.js": "5.2.1",
@@ -49065,8 +49062,6 @@
         "eslint": "8.56.0",
         "eslint-config-custom-server": "*",
         "hono": "4.9.5",
-        "jest": "26.6.3",
-        "jest-presets": "*",
         "keccak256": "1.0.6",
         "nodemon": "2.0.22",
         "pino": "9.0.0",
@@ -49074,7 +49069,8 @@
         "secp256k1": "5.0.0",
         "supertest": "6.3.4",
         "tsconfig": "*",
-        "typescript": "5.0.4"
+        "typescript": "5.0.4",
+        "vitest": "0.34.6"
       },
       "dependencies": {
         "@audius/eth": {


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test.yml` — runs on every PR against `main`, executes `npm test --workspace=@pedalboard/anti-abuse-oracle`.
- Uses Node 24 to match the runtime Dockerfile.

## Context
There was no existing test-running workflow to copy. The existing `.github/workflows/` only build and tag Docker images — neither `solana-relay` nor `notifications` has its tests wired into CI today, despite having `test` scripts. This PR establishes a minimal pattern; future services can add jobs to the same workflow.

## Dependency
Stacked on top of [pedalboard#37](https://github.com/AudiusProject/pedalboard/pull/37) (the AAO vitest suite). Until #37 merges, this PR's diff against `main` shows both the test files and the workflow; once #37 merges, the diff cleans up to just the workflow.

## Test plan
- [x] Workflow YAML syntactically valid (parseable by `actions/setup-node@v4` + `npm`).
- [ ] On this PR's first run, the `anti-abuse-oracle` job passes (25/25 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)