### PR TITLE
aao: expose antiAbuseWalletPubkey in /health_check

### DIFF
--- a/apps/anti-abuse-oracle/src/server.tsx
+++ b/apps/anti-abuse-oracle/src/server.tsx
@@ -37,6 +37,14 @@ const signBytes = (bytes: Buffer, ethPrivateKey: string) => {
   return { signature: Buffer.from(signature), recoveryId: recid }
 }
 
+const ethAddressFromPrivateKey = (ethPrivateKey: string) => {
+  const privateKey = Buffer.from(ethPrivateKey, 'hex')
+  const publicKey = Buffer.from(
+    secp256k1.publicKeyCreate(privateKey, false)
+  ).subarray(1)
+  return '0x' + keccak256(publicKey).subarray(-20).toString('hex')
+}
+
 const CONTENT_NODE = 'https://creatornode2.audius.co'
 const FRONTEND = 'https://audius.co'
 
@@ -107,7 +115,17 @@ const app = new Hono()
 app.use(logger())
 app.use('/attestation/*', cors())
 
-app.get('/health_check', (c) => c.json({ status: 'ok' }, 200))
+app.get('/health_check', (c) =>
+  c.json(
+    {
+      status: 'ok',
+      antiAbuseWalletPubkey: ethAddressFromPrivateKey(
+        config.privateSignerAddress
+      )
+    },
+    200
+  )
+)
 
 app.get('/attestation/check', async (c) => {
   const wallet = c.req.query('wallet')


### PR DESCRIPTION
## Summary
- The Go API reads `antiAbuseWalletPubkey` from the AAO `/health_check` to resolve the oracle's signing wallet, which it uses to verify reward claim attestations. The pedalboard AAO returned only `{ status: 'ok' }` (added in #32), so rewards claiming has been broken.
- Derive the ETH address from `config.privateSignerAddress` (uncompressed secp256k1 pubkey → last 20 bytes of its keccak256 hash) using the deps already on hand from #35, instead of reintroducing ethers.
- Verified the derivation against a known test vector (hardhat account #0): `ac09…ff80` → `0xf39F…2266`.

## Test plan
- [ ] `curl http://<aao>/health_check` returns `{ "status": "ok", "antiAbuseWalletPubkey": "0x…" }`
- [ ] Returned address matches the EVM address of the configured `private_signer_address`
- [ ] Go API picks up the address and rewards claiming succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)