### PR TITLE
trending-rewards: read disbursements from v_challenge_disbursements

### DIFF
--- a/apps/trending-challenge-rewards/src/queries.ts
+++ b/apps/trending-challenge-rewards/src/queries.ts
@@ -34,7 +34,7 @@ export const getChallengesDisbursementsUserbanks = async (
       'u.specifier',
       'c.slot'
     )
-    .leftJoin('challenge_disbursements as c', function () {
+    .leftJoin('v_challenge_disbursements as c', function () {
       this.on('u.specifier', '=', 'c.specifier').andOn(
         'u.challenge_id',
         '=',
@@ -66,7 +66,7 @@ export const getChallengesDisbursementsUserbanksFriendly = async (
       'u.completed_blocknumber',
       'c.slot'
     )
-    .leftJoin('challenge_disbursements as c', function () {
+    .leftJoin('v_challenge_disbursements as c', function () {
       this.on('u.specifier', '=', 'c.specifier').andOn(
         'u.challenge_id',
         '=',


### PR DESCRIPTION
## Summary
- The bot joined `user_challenges` against the legacy `challenge_disbursements` table to confirm each claim landed on Solana. The Go solana indexer no longer writes to that table — new disbursements only land in `sol_reward_disbursements`, exposed in the legacy column shape via the `v_challenge_disbursements` compatibility view.
- Result: every recent `tt` / `tut` disbursement showed a null `Slot` in the post-run Slack table.
- Switch both queries in [queries.ts](apps/trending-challenge-rewards/src/queries.ts) to `v_challenge_disbursements`, matching what the Go API routes (`v1_users_challenges`, `v1_challenges_undisbursed`, `v1_challenges_disbursements`) already do.

## Test plan
- [ ] `npm run lint` in `apps/trending-challenge-rewards` (passes locally — only pre-existing warnings)
- [ ] After deploy, run a disbursement and confirm the Slack `Slot` column is populated for both `tt` and `tut` rows
- [ ] Optionally dry-run via the manual trigger first

🤖 Generated with [Claude Code](https://claude.com/claude-code)