### PR TITLE
TCR: restore signing via createSdkWithServices (bump @audius/sdk to ^15.3.1)

### DIFF
--- a/apps/trending-challenge-rewards/package.json
+++ b/apps/trending-challenge-rewards/package.json
@@ -15,7 +15,7 @@
     "preset": "jest-presets/jest/node"
   },
   "dependencies": {
-    "@audius/sdk": "14.1.0",
+    "@audius/sdk": "^15.3.1",
     "@pedalboard/basekit": "*",
     "@pedalboard/logger": "*",
     "@pedalboard/storage": "*",

--- a/apps/trending-challenge-rewards/src/config.ts
+++ b/apps/trending-challenge-rewards/src/config.ts
@@ -37,6 +37,8 @@ export const initSharedData = async (): Promise<SharedData> => {
 
   sharedData = {
     sdk: audiusSdk({
+      apiKey: process.env.audius_api_key!,
+      apiSecret: process.env.audius_api_secret!,
       environment: process.env.environment as
         | 'development'
         | 'production',

--- a/apps/trending-challenge-rewards/src/sdk.ts
+++ b/apps/trending-challenge-rewards/src/sdk.ts
@@ -4,7 +4,7 @@ import {
   SolanaRelayWalletAdapter,
   SolanaClient,
   SolanaRelay,
-  sdk
+  createSdkWithServices
 } from '@audius/sdk'
 
 const makeAAOSelector = () =>
@@ -46,10 +46,14 @@ const makeSolanaClient = (
 }
 
 export const audiusSdk = ({
+  apiKey,
+  apiSecret,
   environment,
   solanaRpcEndpoint,
   solanaRelayNode
 }: {
+  apiKey: string
+  apiSecret: string
   environment: 'development' | 'production'
   solanaRpcEndpoint?: string
   solanaRelayNode: string
@@ -58,8 +62,10 @@ export const audiusSdk = ({
   const solanaClient = solanaRpcEndpoint
     ? makeSolanaClient(solanaRelay, solanaRpcEndpoint)
     : undefined
-  return sdk({
+  return createSdkWithServices({
     appName: 'trending-challenge-rewards',
+    apiKey,
+    apiSecret,
     environment,
     services: {
       solanaRelay,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4210,7 +4210,7 @@
       "name": "@pedalboard/trending-challenge-rewards",
       "version": "0.0.30",
       "dependencies": {
-        "@audius/sdk": "14.1.0",
+        "@audius/sdk": "^15.3.1",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
         "@pedalboard/storage": "*",
@@ -4247,13 +4247,19 @@
         "typescript": "5.0.4"
       }
     },
+    "apps/trending-challenge-rewards/node_modules/@audius/eth": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
+      "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw==",
+      "license": "Apache-2.0"
+    },
     "apps/trending-challenge-rewards/node_modules/@audius/sdk": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-14.1.0.tgz",
-      "integrity": "sha512-rdOscNsYH5N8Xu3nYPuq1ho3+Ny6Qvjr9OInddSuyqIN5eDUr1CEu/P9s4aUHW7zLA2GVk5gPxwLuVm1XJPAuw==",
+      "version": "15.3.1",
+      "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.3.1.tgz",
+      "integrity": "sha512-cUGQXdUaaqd2uGm6Xa/vgHEKIenJsA/HWb30SzIv5dpILjsBK79ZM7+dBoT84TV0CsNJLuMn+wt1pbgcrOWtiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@audius/eth": "0.1.0",
+        "@audius/eth": "1.0.0",
         "@audius/fixed-decimal": "0.2.1",
         "@audius/hedgehog": "3.0.0-alpha.1",
         "@audius/spl": "2.1.0",
@@ -4274,7 +4280,6 @@
         "form-data": "3.0.0",
         "hashids": "2.2.10",
         "isomorphic-ws": "5.0.0",
-        "lodash": "4.17.21",
         "micro-aes-gcm": "0.4.0",
         "multiformats": "13.3.1",
         "node-abort-controller": "3.1.1",
@@ -4296,7 +4301,17 @@
         "@rollup/rollup-linux-x64-gnu": "4.24.0"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.95.8"
+        "@react-native-async-storage/async-storage": ">=1.0.0",
+        "@solana/web3.js": "^1.95.8",
+        "expo-web-browser": ">=14.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        },
+        "expo-web-browser": {
+          "optional": true
+        }
       }
     },
     "apps/trending-challenge-rewards/node_modules/@noble/curves": {
@@ -52134,7 +52149,7 @@
     "@pedalboard/trending-challenge-rewards": {
       "version": "file:apps/trending-challenge-rewards",
       "requires": {
-        "@audius/sdk": "14.1.0",
+        "@audius/sdk": "^15.3.1",
         "@pedalboard/basekit": "*",
         "@pedalboard/logger": "*",
         "@pedalboard/storage": "*",
@@ -52169,12 +52184,17 @@
         "typescript": "5.0.4"
       },
       "dependencies": {
+        "@audius/eth": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/@audius/eth/-/eth-1.0.0.tgz",
+          "integrity": "sha512-q7kgA7grolH6j8XV8Q13HY97Pn3kp8C0esaUxlvHoy4zWF2q2gIHhq3S/Su3hZcceY25UQ1N7a6OnJRUh0Lufw=="
+        },
         "@audius/sdk": {
-          "version": "14.1.0",
-          "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-14.1.0.tgz",
-          "integrity": "sha512-rdOscNsYH5N8Xu3nYPuq1ho3+Ny6Qvjr9OInddSuyqIN5eDUr1CEu/P9s4aUHW7zLA2GVk5gPxwLuVm1XJPAuw==",
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/@audius/sdk/-/sdk-15.3.1.tgz",
+          "integrity": "sha512-cUGQXdUaaqd2uGm6Xa/vgHEKIenJsA/HWb30SzIv5dpILjsBK79ZM7+dBoT84TV0CsNJLuMn+wt1pbgcrOWtiQ==",
           "requires": {
-            "@audius/eth": "0.1.0",
+            "@audius/eth": "1.0.0",
             "@audius/fixed-decimal": "0.2.1",
             "@audius/hedgehog": "3.0.0-alpha.1",
             "@audius/spl": "2.1.0",
@@ -52196,7 +52216,6 @@
             "form-data": "3.0.0",
             "hashids": "2.2.10",
             "isomorphic-ws": "5.0.0",
-            "lodash": "4.17.21",
             "micro-aes-gcm": "0.4.0",
             "multiformats": "13.3.1",
             "node-abort-controller": "3.1.1",


### PR DESCRIPTION
## Summary

- Re-applies [044f0e2](https://github.com/AudiusProject/pedalboard/commit/044f0e2a955dc3acb168bff875405678b34202b4) (reverted in [2d9f65d](https://github.com/AudiusProject/pedalboard/commit/2d9f65de6446b0e4cc9eac4239db452da2141a2c)).
- Bumps `@audius/sdk` from `14.1.0` to `^15.3.1` in `trending-challenge-rewards` and switches the bot from the no-auth `sdk()` factory back to `createSdkWithServices`, passing `apiKey`/`apiSecret` from env.

## Why

Reward disbursement slots are coming back null for everyone in prod. The bot's `claimRewards` calls fail before they leave the pod with:

> Method 'personal_sign' not implemented on local transport

because the no-auth `sdk()` factory leaves the underlying transport with no wallet configured (the failed signature attempt shows the zero address). No Solana transactions are sent, nothing gets indexed, and `slot` stays null for every recipient.

## Why this is safe now

The original revert ([2d9f65d](https://github.com/AudiusProject/pedalboard/commit/2d9f65de6446b0e4cc9eac4239db452da2141a2c)) was driven by a runtime issue with `@audius/sdk@15.3.1`. The same bump has since landed successfully for the anti-abuse-oracle service in [#34](https://github.com/AudiusProject/pedalboard/pull/34) (`ec374ba`), which runs against the same Node 24 base image. `15.3.1` is still the latest published version on npm.

The GCP secrets (`trending-challenge-rewards-audius_api_key`, `trending-challenge-rewards-audius_api_secret`) were already provisioned when `044f0e2` first landed, so no infra changes are needed.

## Test plan

- [x] `npm run build --workspace=apps/trending-challenge-rewards` — passes
- [x] `npm run lint --workspace=apps/trending-challenge-rewards` — passes (existing warnings only, no new errors)
- [ ] Deploy to prod, then verify the next scheduled run claims rewards and disbursement rows populate `slot` instead of null

🤖 Generated with [Claude Code](https://claude.com/claude-code)