### PR TITLE
notifications: fix "earned undefined AUDIO" push for Spend to Earn

### DIFF
--- a/apps/notifications/src/__tests__/mappings/challengeReward.test.ts
+++ b/apps/notifications/src/__tests__/mappings/challengeReward.test.ts
@@ -76,6 +76,48 @@ describe('Challenge Reward Notification', () => {
     )
   })
 
+  test('Process push notification for Spend to Earn (b) interpolates amount from payload', async () => {
+    await createUsers(processor.discoveryDB, [{ user_id: 1 }])
+    await createRewardManagerTx(processor.discoveryDB, [
+      { slot: 2, signature: '0x2' }
+    ])
+    await createChallengeReward(processor.discoveryDB, [
+      {
+        challenge_id: 'b',
+        user_id: 1,
+        specifier: '1',
+        amount: '500000000',
+        created_at: new Date(1589373217)
+      }
+    ])
+    await insertMobileSettings(processor.identityDB, [{ userId: 1 }])
+    await insertMobileDevices(processor.identityDB, [{ userId: 1 }])
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    const pending = processor.listener.takePending()
+    const challengeNotifications = pending?.appNotifications.filter(
+      (n) => n.type === 'challenge_reward'
+    )
+
+    expect(challengeNotifications).toHaveLength(1)
+    await processor.appNotificationsProcessor.process(challengeNotifications)
+
+    expect(sendPushNotificationSpy).toHaveBeenCalledWith(
+      {
+        type: 'ios',
+        targetARN: 'arn:1',
+        badgeCount: 1
+      },
+      {
+        title: `🛒 Spend to Earn`,
+        body: `You’ve earned 5 $AUDIO for completing this challenge!`,
+        data: {
+          id: 'timestamp:1589373:group_id:challenge_reward:1:challenge:b:specifier:1',
+          type: 'ChallengeReward'
+        }
+      }
+    )
+  })
+
   test('Render a single challenge reward email', async () => {
     await createUsers(processor.discoveryDB, [{ user_id: 1 }, { user_id: 2 }])
 

--- a/apps/notifications/src/processNotifications/mappers/challengeReward.ts
+++ b/apps/notifications/src/processNotifications/mappers/challengeReward.ts
@@ -96,7 +96,11 @@ export class ChallengeReward extends BaseNotification<ChallengeRewardRow> {
       return `You’ve received ${
         this.challengeInfoMap[this.challengeId].amount
       } $AUDIO for being referred! Invite your friends to join to earn more!`
-    } else if (this.challengeId === 'o') {
+    }
+    // Challenges with variable per-user rewards (no fixed amount in
+    // challengeInfoMap) — read the amount from the notification payload.
+    const variableAmountChallenges: string[] = ['o', 'b', 's']
+    if (variableAmountChallenges.includes(this.challengeId)) {
       return `You’ve earned ${
         this.amount / AUDIO_DIVISOR
       } $AUDIO for completing this challenge!`


### PR DESCRIPTION
## Summary
- Spend-to-Earn (`b`) and Sell-to-Earn (`s`) push notifications were rendering as **"You've earned undefined $AUDIO for completing this challenge!"** because the static `challengeInfoMap` entries for those challenges intentionally have no `amount` (the reward is variable per user), but `getPushBodyText` was always reading `challengeInfoMap[challengeId].amount` for every challenge except `'rd'` and `'o'`.
- Fix: route `b` and `s` through the same branch as `o`, which already reads the variable amount off the notification payload as `this.amount / AUDIO_DIVISOR`.

### Bug source
[`apps/notifications/src/processNotifications/mappers/challengeReward.ts`](apps/notifications/src/processNotifications/mappers/challengeReward.ts) — `challengeInfoMap`:
```ts
s: { title: '💸 Sell to Earn' },    // no amount
b: { title: '🛒 Spend to Earn' }    // no amount
```
…combined with the fallback body:
```ts
return `You’ve earned ${this.challengeInfoMap[this.challengeId].amount} $AUDIO for completing this challenge!`
```
…produces `undefined`.

### Fix
```ts
const variableAmountChallenges: string[] = ['o', 'b', 's']
if (variableAmountChallenges.includes(this.challengeId)) {
  return `You’ve earned ${this.amount / AUDIO_DIVISOR} $AUDIO for completing this challenge!`
}
```

Includes a regression test asserting the `b` push body interpolates the payload amount (`500000000` wei → `5 $AUDIO`).

## Test plan
- [x] `npx tsc --noEmit` passes for `apps/notifications`
- [ ] CI: `challengeReward.test.ts` — both the existing `p` test and the new Spend-to-Earn `b` regression test pass (local Jest is broken on this machine due to Node 18 / npm 11 incompatibility; relying on CI)
- [ ] Manual: trigger a Spend-to-Earn challenge disbursement in a test env and confirm the resulting push notification body reads `"You've earned N $AUDIO for completing this challenge!"` with `N` matching the payload amount

🤖 Generated with [Claude Code](https://claude.com/claude-code)