### PR TITLE
TCR: fix /disburse YYYY-MM-DD re-run silently dropping the targeted week

### DIFF
--- a/apps/trending-challenge-rewards/src/queries.ts
+++ b/apps/trending-challenge-rewards/src/queries.ts
@@ -141,21 +141,3 @@ export const getTrendingChallengesByDate = async (
     .where('specifier', 'like', `${specifierPrefix}%`)
     .limit(100)
 
-// Get the completed block number from the first record that's older than 8 days ago
-export const getCompletedBlockNumberFromDaysAgo = async (
-  discoveryDb: Knex,
-  daysAgo: number
-): Promise<number | null> => {
-  const daysAgoDate = new Date()
-  daysAgoDate.setDate(daysAgoDate.getDate() - daysAgo)
-
-  const result = await discoveryDb
-    .select('completed_blocknumber')
-    .from<UserChallenges>(Table.UserChallenges)
-    .where('challenge_id', '=', 'tt')
-    .where('created_at', '<', daysAgoDate)
-    .orderBy('created_at', 'desc')
-    .first()
-
-  return result?.completed_blocknumber || null
-}

--- a/apps/trending-challenge-rewards/src/rewards.ts
+++ b/apps/trending-challenge-rewards/src/rewards.ts
@@ -5,8 +5,7 @@ import { SharedData } from './config'
 import {
   getChallengesDisbursementsUserbanksFriendlyEnsureSlots,
   getTrendingChallenges,
-  getTrendingChallengesByDate,
-  getCompletedBlockNumberFromDaysAgo
+  getTrendingChallengesByDate
 } from './queries'
 import { WebClient } from '@slack/web-api'
 import { formatDisbursementTable } from './slack'
@@ -80,12 +79,7 @@ export const onDisburse = async (
     console.log('endpoint = ', apiEndpoint)
     const toDisburse: Challenge[] = []
     for (const challengeId of TRENDING_REWARD_IDS) {
-      let completedBlocknumber = await getCompletedBlockNumberFromDaysAgo(db, 6)
-      if (completedBlocknumber === null) {
-        console.error('Could not find a completed block number')
-        completedBlocknumber = 0
-      }
-      const url = `${apiEndpoint}/v1/challenges/undisbursed?challenge_id=${challengeId}&completed_blocknumber=${completedBlocknumber}`
+      const url = `${apiEndpoint}/v1/challenges/undisbursed?challenge_id=${challengeId}&completed_blocknumber=${completedBlock}`
       console.log('fetching undisbursed challenges from url = ', url)
       // Fetch all undisbursed challenges
       const res = await axios.get(url)


### PR DESCRIPTION
## Summary
- \`onDisburse\` resolved \`completedBlock\` from either \`findStartingBlock\` (cron) or \`getTrendingChallengesByDate(targetSpecifier)\` (\`/disburse YYYY-MM-DD\` re-run), but the inner loop ignored it and re-fetched a \"6 days ago\" block via \`getCompletedBlockNumberFromDaysAgo(db, 6)\`.
- The api filter is strict \`completed_blocknumber > ?\` (\`api/v1_challenges_undisbursed.go:68\`). On a re-run for an older week, the 6-days-ago block excluded the targeted week's challenges, so the loop fetched zero rows and attempted zero claims. The Slack output still showed the original \`LEFT JOIN\` nulls — making the re-run look like the claims failed again when in fact none ran.
- Use \`completedBlock\` directly (both branches already produce \`block - 1\`). Remove the now-unused helper.

## Context
Verified via the live api: \`/v1/challenges/undisbursed?challenge_id=tt&completed_blocknumber=118999896\` (what TCR sent on the 2026-05-15 re-run) returns 0 rows; \`completed_blocknumber=118999895\` (what \`completedBlock\` resolves to) returns the 6 stuck 2026-05-15 entries.

## Test plan
- [ ] Lint/typecheck passes (\`npm run lint\` in apps/trending-challenge-rewards — done locally, 0 errors)
- [ ] After deploy, re-run \`/disburse 2026-05-15\` in Slack and confirm \"Claiming reward for challengeId\" appears in TCR pod logs for the 10 stuck entries
- [ ] Confirm Slack output shows real slots populated (not nulls) for the previously stuck rank-6–10 winners
- [ ] Confirm the normal Friday cron still picks up the latest week (\`completedBlock\` from \`findStartingBlock\` is the most-recent-tt-block minus 1, same semantics as before for the cron path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)