### PR TITLE
trending-rewards: show trending date in disbursement table title

### DIFF
--- a/apps/trending-challenge-rewards/src/rewards.ts
+++ b/apps/trending-challenge-rewards/src/rewards.ts
@@ -171,7 +171,7 @@ export const onDisburse = async (
   )
 
   // Format the results for Slack
-  const formattedResults = formatDisbursementTable(friendly)
+  const formattedResults = formatDisbursementTable(friendly, trimmedSpecifier)
   console.log(formattedResults)
 
   if (slackChannel === undefined) return new Err('SLACK_CHANNEL not defined')

--- a/apps/trending-challenge-rewards/src/slack.ts
+++ b/apps/trending-challenge-rewards/src/slack.ts
@@ -87,7 +87,8 @@ const trending = async (
 }
 
 export const formatDisbursementTable = (
-  challenges: ChallengeDisbursementUserbankFriendly[]
+  challenges: ChallengeDisbursementUserbankFriendly[],
+  date?: string
 ): string => {
   const matrix = challenges.map((challenge) => [
     challenge.challenge_id,
@@ -95,7 +96,10 @@ export const formatDisbursementTable = (
     challenge.slot
   ])
   console.log(matrix)
-  return new AsciiTable3('Challenge Disbursements')
+  const title = date
+    ? `Challenge Disbursements (${date})`
+    : 'Challenge Disbursements'
+  return new AsciiTable3(title)
     .setHeading('Challenge', 'Handle', 'Slot')
     .setAlign(3, AlignmentEnum.CENTER)
     .addRowMatrix(matrix)


### PR DESCRIPTION
## Summary
- The post-run Slack disbursement table was titled just `Challenge Disbursements`, giving no indication of which trending date it covered.
- `formatDisbursementTable` now takes an optional `date` and folds it into the title, so the table reads `Challenge Disbursements (YYYY-MM-DD)`.
- `onDisburse` passes `trimmedSpecifier` (the trending date / specifier prefix) at the call site.

## Test plan
- [ ] Run `/disburse <YYYY-MM-DD>` (or a dry run) and confirm the Slack table title includes the date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)