### PR TITLE
notifications: automated inactive-user trigger sending + open-rate tracking

### DIFF
--- a/apps/notifications/src/__tests__/mappings/addTrackToPlaylist.test.ts
+++ b/apps/notifications/src/__tests__/mappings/addTrackToPlaylist.test.ts
@@ -119,8 +119,7 @@ describe('Add track to playlist notification', () => {
         type: 'track_added_to_playlist',
         timestamp: new Date(),
         specifier: '1',
-        group_id:
-          'track_added_to_playlist:playlist_id:55:track_id:10',
+        group_id: 'track_added_to_playlist:playlist_id:55:track_id:10',
         data,
         user_ids: [1],
         receiver_user_id: 1

--- a/apps/notifications/src/main.ts
+++ b/apps/notifications/src/main.ts
@@ -19,6 +19,7 @@ import { AppNotificationsProcessor } from './processNotifications/indexAppNotifi
 import { sendDMNotifications } from './tasks/dmNotifications'
 import { processEmailNotifications } from './email/notifications/index'
 import { sendAppNotifications } from './tasks/appNotifications'
+import { sendInactiveUserNotifications } from './tasks/inactiveUserNotifications'
 import {
   BrowserPluginMappings,
   BrowserPushPlugin,
@@ -183,6 +184,8 @@ export type NotificationsAppData = {
   listenerPendingNotificationIds: number[]
   lastDailyEmailSent: moment.Moment | null
   lastWeeklyEmailSent: moment.Moment | null
+  /** Last time automated inactivity triggers were checked and sent. Runs hourly. */
+  lastInactivityTriggerRun: moment.Moment | null
 }
 
 function getIsScheduledEmailEnabled(remoteConfig: RemoteConfig): boolean {
@@ -253,7 +256,8 @@ async function main() {
     listenerPending,
     listenerPendingNotificationIds: [],
     lastDailyEmailSent: null,
-    lastWeeklyEmailSent: null
+    lastWeeklyEmailSent: null,
+    lastInactivityTriggerRun: null
   }
 
   const server = new Server()
@@ -414,6 +418,28 @@ async function main() {
         self.updateAppData((d) => ({
           ...d,
           lastWeeklyEmailSent: moment.utc()
+        }))
+      }
+
+      // Automated inactivity triggers: run once per hour.
+      // Sends push notifications to users who just crossed each trigger's
+      // inactivity threshold and logs sends to Supabase for open-rate tracking.
+      if (
+        !data.lastInactivityTriggerRun ||
+        data.lastInactivityTriggerRun < moment.utc().subtract(1, 'hours')
+      ) {
+        logger.info('Processing automated inactivity trigger notifications')
+        try {
+          await sendInactiveUserNotifications(self.getDnDb())
+        } catch (e) {
+          logger.error(
+            { err: e },
+            'tick: sendInactiveUserNotifications threw unexpectedly'
+          )
+        }
+        self.updateAppData((d) => ({
+          ...d,
+          lastInactivityTriggerRun: moment.utc()
         }))
       }
     })

--- a/apps/notifications/src/main.ts
+++ b/apps/notifications/src/main.ts
@@ -19,7 +19,6 @@ import { AppNotificationsProcessor } from './processNotifications/indexAppNotifi
 import { sendDMNotifications } from './tasks/dmNotifications'
 import { processEmailNotifications } from './email/notifications/index'
 import { sendAppNotifications } from './tasks/appNotifications'
-import { sendInactiveUserNotifications } from './tasks/inactiveUserNotifications'
 import {
   BrowserPluginMappings,
   BrowserPushPlugin,
@@ -184,8 +183,6 @@ export type NotificationsAppData = {
   listenerPendingNotificationIds: number[]
   lastDailyEmailSent: moment.Moment | null
   lastWeeklyEmailSent: moment.Moment | null
-  /** Last time automated inactivity triggers were checked and sent. Runs hourly. */
-  lastInactivityTriggerRun: moment.Moment | null
 }
 
 function getIsScheduledEmailEnabled(remoteConfig: RemoteConfig): boolean {
@@ -256,8 +253,7 @@ async function main() {
     listenerPending,
     listenerPendingNotificationIds: [],
     lastDailyEmailSent: null,
-    lastWeeklyEmailSent: null,
-    lastInactivityTriggerRun: null
+    lastWeeklyEmailSent: null
   }
 
   const server = new Server()
@@ -418,28 +414,6 @@ async function main() {
         self.updateAppData((d) => ({
           ...d,
           lastWeeklyEmailSent: moment.utc()
-        }))
-      }
-
-      // Automated inactivity triggers: run once per hour.
-      // Sends push notifications to users who just crossed each trigger's
-      // inactivity threshold and logs sends to Supabase for open-rate tracking.
-      if (
-        !data.lastInactivityTriggerRun ||
-        data.lastInactivityTriggerRun < moment.utc().subtract(1, 'hours')
-      ) {
-        logger.info('Processing automated inactivity trigger notifications')
-        try {
-          await sendInactiveUserNotifications(self.getDnDb())
-        } catch (e) {
-          logger.error(
-            { err: e },
-            'tick: sendInactiveUserNotifications threw unexpectedly'
-          )
-        }
-        self.updateAppData((d) => ({
-          ...d,
-          lastInactivityTriggerRun: moment.utc()
         }))
       }
     })

--- a/apps/notifications/src/server/index.ts
+++ b/apps/notifications/src/server/index.ts
@@ -6,7 +6,6 @@ import { router as healthCheckRouter } from './routes/healthCheck'
 import { router as memStatsRouter } from './routes/memStats'
 import { createSendAnnouncementRouter } from './routes/sendAnnouncement'
 import { createSendWelcomeEmailRouter } from './routes/sendWelcomeEmail'
-import { createInactiveUsersRouter } from './routes/inactiveUsers'
 
 const DEFAULT_PORT = 6000
 
@@ -32,10 +31,6 @@ export class Server {
       this.app.use(
         '/internal/send-welcome-email',
         createSendWelcomeEmailRouter(identityDb)
-      )
-      this.app.use(
-        '/internal/inactive-users',
-        createInactiveUsersRouter(discoveryDb)
       )
     }
 

--- a/apps/notifications/src/server/routes/inactiveUsers.ts
+++ b/apps/notifications/src/server/routes/inactiveUsers.ts
@@ -1,7 +1,10 @@
 import { Router, Request, Response } from 'express'
 import { Knex } from 'knex'
 import { logger } from '../../logger'
-import { findInactiveUsers } from '../../tasks/inactiveUserNotifications'
+import {
+  findInactiveUsers,
+  insertTriggerNotification
+} from '../../tasks/inactiveUserNotifications'
 
 // Hard ceiling on returned ids regardless of requested limit (flood protection).
 const MAX_LIMIT = 100000
@@ -14,6 +17,7 @@ function parsePositiveNumber(value: unknown): number | null {
 
 export function createInactiveUsersRouter(discoveryDb: Knex): Router {
   const router = Router()
+
   router.get('/', async (req: Request, res: Response) => {
     const secret = process.env.ANNOUNCEMENT_SEND_SECRET
     if (!secret) {
@@ -57,5 +61,67 @@ export function createInactiveUsersRouter(discoveryDb: Knex): Router {
       })
     }
   })
+
+  router.post('/', async (req: Request, res: Response) => {
+    const secret = process.env.ANNOUNCEMENT_SEND_SECRET
+    if (!secret) {
+      res.status(503).json({
+        error:
+          'inactive-users is disabled: set ANNOUNCEMENT_SEND_SECRET in env to enable.'
+      })
+      return
+    }
+    if (req.headers.authorization !== `Bearer ${secret}`) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+
+    const {
+      id,
+      trigger_hours,
+      heading,
+      body,
+      cta_link = null,
+      image_url = null
+    } = req.body as {
+      id: string
+      trigger_hours: number
+      heading: string
+      body: string
+      cta_link?: string | null
+      image_url?: string | null
+    }
+
+    const hours = parsePositiveNumber(trigger_hours)
+    if (!id || !heading || !body || hours === null) {
+      res.status(400).json({
+        error:
+          'Missing or invalid required fields: id, trigger_hours, heading, body'
+      })
+      return
+    }
+
+    try {
+      const userIds = await findInactiveUsers(discoveryDb, hours, 1, 100_000)
+      if (userIds.length === 0) {
+        res.json({ sent: 0 })
+        return
+      }
+      await insertTriggerNotification(
+        discoveryDb,
+        { id, heading, body, cta_link, image_url },
+        userIds,
+        new Date()
+      )
+      res.json({ sent: userIds.length })
+    } catch (e) {
+      logger.error(e, 'inactive-users trigger send failed')
+      res.status(500).json({
+        error:
+          e instanceof Error ? e.message : 'inactive-users trigger send failed'
+      })
+    }
+  })
+
   return router
 }

--- a/apps/notifications/src/server/routes/inactiveUsers.ts
+++ b/apps/notifications/src/server/routes/inactiveUsers.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express'
 import { Knex } from 'knex'
 import { logger } from '../../logger'
+import { findInactiveUsers } from '../../tasks/inactiveUserNotifications'
 
 // Hard ceiling on returned ids regardless of requested limit (flood protection).
 const MAX_LIMIT = 100000
@@ -9,43 +10,6 @@ const DEFAULT_WINDOW_HOURS = 1
 function parsePositiveNumber(value: unknown): number | null {
   const n = Number(value)
   return Number.isFinite(n) && n > 0 ? n : null
-}
-
-/**
- * Users whose most recent activity aged into the [hours, hours + windowHours)
- * band and who have no activity since `hours` ago — i.e. they just crossed the
- * inactivity threshold. Callers run this on a cadence equal to windowHours so
- * each user is returned exactly once per inactivity episode (the band is the
- * dedup; no per-user state needed).
- *
- * NOTE: "activity" is currently a discovery `plays` row. If we move to an
- * app-open signal (identity service), only this query changes.
- */
-async function findInactiveUsers(
-  discoveryDb: Knex,
-  hours: number,
-  windowHours: number,
-  limit: number
-): Promise<number[]> {
-  const rows = await discoveryDb
-    .select<{ user_id: number }[]>('p.user_id')
-    .from({ p: 'plays' })
-    .whereNotNull('p.user_id')
-    .andWhereRaw("p.created_at >= now() - (? * interval '1 hour')", [
-      hours + windowHours
-    ])
-    .andWhereRaw("p.created_at < now() - (? * interval '1 hour')", [hours])
-    .whereNotExists(function () {
-      this.select(discoveryDb.raw('1'))
-        .from({ p2: 'plays' })
-        .whereRaw('p2.user_id = p.user_id')
-        .andWhereRaw("p2.created_at >= now() - (? * interval '1 hour')", [
-          hours
-        ])
-    })
-    .groupBy('p.user_id')
-    .limit(limit)
-  return rows.map((r) => r.user_id)
 }
 
 export function createInactiveUsersRouter(discoveryDb: Knex): Router {

--- a/apps/notifications/src/tasks/inactiveUserNotifications.ts
+++ b/apps/notifications/src/tasks/inactiveUserNotifications.ts
@@ -1,29 +1,24 @@
 /**
- * Automated re-engagement notifications for inactive users.
+ * Inactive-user notification helpers.
  *
- * Reads active trigger configs from the notifications dashboard Supabase DB,
- * finds users who just crossed each inactivity threshold (via the plays table),
- * inserts a notification row into the discovery DB (picked up by the existing
- * push send pipeline), and logs each send to trigger_sends in Supabase so the
- * dashboard can compute audience_reached_30d and open_rate_30d.
+ * findInactiveUsers: queries the discovery DB plays table for users who just
+ * crossed an inactivity window.
  *
- * The trigger UUID is used as the notification_campaign_id so Discovery can
- * attribute push opens back to the trigger for open-rate tracking.
+ * insertTriggerNotification: inserts a single announcement notification row
+ * into the discovery DB for the given user IDs (picked up by the existing push
+ * send pipeline).
  */
 
 import { Knex } from 'knex'
-import { logger } from '../logger'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type AutomatedTrigger = {
+export type TriggerPayload = {
   id: string
-  name: string
   heading: string
   body: string
-  trigger_hours: number
   cta_link: string | null
   image_url: string | null
 }
@@ -31,8 +26,6 @@ type AutomatedTrigger = {
 // ---------------------------------------------------------------------------
 // Core inactive-user query (shared with /internal/inactive-users route)
 // ---------------------------------------------------------------------------
-
-const DEFAULT_WINDOW_HOURS = 1
 
 /**
  * Returns user IDs whose most recent play aged into the
@@ -68,129 +61,34 @@ export async function findInactiveUsers(
 }
 
 // ---------------------------------------------------------------------------
-// Supabase helpers (raw pg via knex — no REST layer needed)
+// Discovery DB notification insert
 // ---------------------------------------------------------------------------
 
-function getDashboardDb(): Knex | null {
-  const url = process.env.DASHBOARD_DB_URL
-  if (!url?.trim()) return null
-  // Lazy require so the rest of the app doesn't pay the cost when unconfigured.
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { knex } = require('knex') as typeof import('knex')
-  return knex({ client: 'pg', connection: url, pool: { min: 1, max: 3 } })
-}
-
-let _dashboardDb: Knex | null | undefined
-function dashboardDb(): Knex | null {
-  if (_dashboardDb === undefined) _dashboardDb = getDashboardDb()
-  return _dashboardDb
-}
-
-async function fetchActiveTriggers(db: Knex): Promise<AutomatedTrigger[]> {
-  return db('automated_triggers')
-    .select('id', 'name', 'heading', 'body', 'trigger_hours', 'cta_link', 'image_url')
-    .where('is_active', true)
-}
-
-async function logTriggerSends(
-  db: Knex,
-  triggerId: string,
+/**
+ * Inserts a single announcement notification row into the discovery DB for the
+ * given user IDs. The existing push pipeline fans the notification out to each
+ * user's devices. notification_campaign_id = trigger UUID so Discovery can
+ * count opens for open-rate tracking.
+ */
+export async function insertTriggerNotification(
+  discoveryDb: Knex,
+  trigger: TriggerPayload,
   userIds: number[],
   sentAt: Date
 ): Promise<void> {
-  if (userIds.length === 0) return
-  const rows = userIds.map((userId) => ({
-    trigger_id: triggerId,
-    user_id: userId,
-    sent_at: sentAt.toISOString()
-  }))
-  await db('trigger_sends').insert(rows)
-}
-
-// ---------------------------------------------------------------------------
-// Main task
-// ---------------------------------------------------------------------------
-
-const MAX_USERS_PER_TRIGGER = 100_000
-
-/**
- * For each active trigger, find newly-inactive users and send them a push
- * notification via the discovery DB notification pipeline.
- */
-export async function sendInactiveUserNotifications(
-  discoveryDb: Knex
-): Promise<void> {
-  const db = dashboardDb()
-  if (!db) {
-    logger.debug(
-      'inactive-user notifications: DASHBOARD_DB_URL not set, skipping'
-    )
-    return
-  }
-
-  let triggers: AutomatedTrigger[]
-  try {
-    triggers = await fetchActiveTriggers(db)
-  } catch (e) {
-    logger.error({ err: e }, 'inactive-user notifications: failed to fetch triggers')
-    return
-  }
-
-  if (triggers.length === 0) {
-    logger.debug('inactive-user notifications: no active triggers')
-    return
-  }
-
-  const sentAt = new Date()
-
-  for (const trigger of triggers) {
-    try {
-      const userIds = await findInactiveUsers(
-        discoveryDb,
-        trigger.trigger_hours,
-        DEFAULT_WINDOW_HOURS,
-        MAX_USERS_PER_TRIGGER
-      )
-
-      if (userIds.length === 0) {
-        logger.info(
-          { trigger: trigger.name, hours: trigger.trigger_hours },
-          'inactive-user notifications: no users in window'
-        )
-        continue
-      }
-
-      logger.info(
-        { trigger: trigger.name, hours: trigger.trigger_hours, count: userIds.length },
-        'inactive-user notifications: sending'
-      )
-
-      // Insert a single notification row; the existing push pipeline fans it
-      // out to each user's devices. notification_campaign_id = trigger UUID
-      // so Discovery can count opens for open-rate tracking.
-      await discoveryDb('notification').insert({
-        specifier: '',
-        group_id: `inactivity-trigger:${trigger.id}:${sentAt.getTime()}`,
-        type: 'announcement',
-        timestamp: sentAt,
-        user_ids: userIds,
-        data: {
-          title: trigger.heading,
-          short_description: trigger.body,
-          push_body: trigger.body,
-          notification_campaign_id: trigger.id,
-          ...(trigger.cta_link ? { route: trigger.cta_link } : {}),
-          ...(trigger.image_url ? { image_url: trigger.image_url } : {})
-        }
-      })
-
-      // Log sends to Supabase for audience_reached_30d computation.
-      await logTriggerSends(db, trigger.id, userIds, sentAt)
-    } catch (e) {
-      logger.error(
-        { err: e, trigger: trigger.name },
-        'inactive-user notifications: error processing trigger'
-      )
+  await discoveryDb('notification').insert({
+    specifier: '',
+    group_id: `inactivity-trigger:${trigger.id}:${sentAt.getTime()}`,
+    type: 'announcement',
+    timestamp: sentAt,
+    user_ids: userIds,
+    data: {
+      title: trigger.heading,
+      short_description: trigger.body,
+      push_body: trigger.body,
+      notification_campaign_id: trigger.id,
+      ...(trigger.cta_link ? { route: trigger.cta_link } : {}),
+      ...(trigger.image_url ? { image_url: trigger.image_url } : {})
     }
-  }
+  })
 }

--- a/apps/notifications/src/tasks/inactiveUserNotifications.ts
+++ b/apps/notifications/src/tasks/inactiveUserNotifications.ts
@@ -1,0 +1,196 @@
+/**
+ * Automated re-engagement notifications for inactive users.
+ *
+ * Reads active trigger configs from the notifications dashboard Supabase DB,
+ * finds users who just crossed each inactivity threshold (via the plays table),
+ * inserts a notification row into the discovery DB (picked up by the existing
+ * push send pipeline), and logs each send to trigger_sends in Supabase so the
+ * dashboard can compute audience_reached_30d and open_rate_30d.
+ *
+ * The trigger UUID is used as the notification_campaign_id so Discovery can
+ * attribute push opens back to the trigger for open-rate tracking.
+ */
+
+import { Knex } from 'knex'
+import { logger } from '../logger'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type AutomatedTrigger = {
+  id: string
+  name: string
+  heading: string
+  body: string
+  trigger_hours: number
+  cta_link: string | null
+  image_url: string | null
+}
+
+// ---------------------------------------------------------------------------
+// Core inactive-user query (shared with /internal/inactive-users route)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_WINDOW_HOURS = 1
+
+/**
+ * Returns user IDs whose most recent play aged into the
+ * [hours, hours + windowHours) band with no subsequent activity.
+ * Callers should run this on a cadence equal to windowHours so each
+ * user is returned exactly once per inactivity episode.
+ */
+export async function findInactiveUsers(
+  discoveryDb: Knex,
+  hours: number,
+  windowHours: number,
+  limit: number
+): Promise<number[]> {
+  const rows = await discoveryDb
+    .select<{ user_id: number }[]>('p.user_id')
+    .from({ p: 'plays' })
+    .whereNotNull('p.user_id')
+    .andWhereRaw("p.created_at >= now() - (? * interval '1 hour')", [
+      hours + windowHours
+    ])
+    .andWhereRaw("p.created_at < now() - (? * interval '1 hour')", [hours])
+    .whereNotExists(function () {
+      this.select(discoveryDb.raw('1'))
+        .from({ p2: 'plays' })
+        .whereRaw('p2.user_id = p.user_id')
+        .andWhereRaw("p2.created_at >= now() - (? * interval '1 hour')", [
+          hours
+        ])
+    })
+    .groupBy('p.user_id')
+    .limit(limit)
+  return rows.map((r) => r.user_id)
+}
+
+// ---------------------------------------------------------------------------
+// Supabase helpers (raw pg via knex — no REST layer needed)
+// ---------------------------------------------------------------------------
+
+function getDashboardDb(): Knex | null {
+  const url = process.env.DASHBOARD_DB_URL
+  if (!url?.trim()) return null
+  // Lazy require so the rest of the app doesn't pay the cost when unconfigured.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { knex } = require('knex') as typeof import('knex')
+  return knex({ client: 'pg', connection: url, pool: { min: 1, max: 3 } })
+}
+
+let _dashboardDb: Knex | null | undefined
+function dashboardDb(): Knex | null {
+  if (_dashboardDb === undefined) _dashboardDb = getDashboardDb()
+  return _dashboardDb
+}
+
+async function fetchActiveTriggers(db: Knex): Promise<AutomatedTrigger[]> {
+  return db('automated_triggers')
+    .select('id', 'name', 'heading', 'body', 'trigger_hours', 'cta_link', 'image_url')
+    .where('is_active', true)
+}
+
+async function logTriggerSends(
+  db: Knex,
+  triggerId: string,
+  userIds: number[],
+  sentAt: Date
+): Promise<void> {
+  if (userIds.length === 0) return
+  const rows = userIds.map((userId) => ({
+    trigger_id: triggerId,
+    user_id: userId,
+    sent_at: sentAt.toISOString()
+  }))
+  await db('trigger_sends').insert(rows)
+}
+
+// ---------------------------------------------------------------------------
+// Main task
+// ---------------------------------------------------------------------------
+
+const MAX_USERS_PER_TRIGGER = 100_000
+
+/**
+ * For each active trigger, find newly-inactive users and send them a push
+ * notification via the discovery DB notification pipeline.
+ */
+export async function sendInactiveUserNotifications(
+  discoveryDb: Knex
+): Promise<void> {
+  const db = dashboardDb()
+  if (!db) {
+    logger.debug(
+      'inactive-user notifications: DASHBOARD_DB_URL not set, skipping'
+    )
+    return
+  }
+
+  let triggers: AutomatedTrigger[]
+  try {
+    triggers = await fetchActiveTriggers(db)
+  } catch (e) {
+    logger.error({ err: e }, 'inactive-user notifications: failed to fetch triggers')
+    return
+  }
+
+  if (triggers.length === 0) {
+    logger.debug('inactive-user notifications: no active triggers')
+    return
+  }
+
+  const sentAt = new Date()
+
+  for (const trigger of triggers) {
+    try {
+      const userIds = await findInactiveUsers(
+        discoveryDb,
+        trigger.trigger_hours,
+        DEFAULT_WINDOW_HOURS,
+        MAX_USERS_PER_TRIGGER
+      )
+
+      if (userIds.length === 0) {
+        logger.info(
+          { trigger: trigger.name, hours: trigger.trigger_hours },
+          'inactive-user notifications: no users in window'
+        )
+        continue
+      }
+
+      logger.info(
+        { trigger: trigger.name, hours: trigger.trigger_hours, count: userIds.length },
+        'inactive-user notifications: sending'
+      )
+
+      // Insert a single notification row; the existing push pipeline fans it
+      // out to each user's devices. notification_campaign_id = trigger UUID
+      // so Discovery can count opens for open-rate tracking.
+      await discoveryDb('notification').insert({
+        specifier: '',
+        group_id: `inactivity-trigger:${trigger.id}:${sentAt.getTime()}`,
+        type: 'announcement',
+        timestamp: sentAt,
+        user_ids: userIds,
+        data: {
+          title: trigger.heading,
+          short_description: trigger.body,
+          push_body: trigger.body,
+          notification_campaign_id: trigger.id,
+          ...(trigger.cta_link ? { route: trigger.cta_link } : {}),
+          ...(trigger.image_url ? { image_url: trigger.image_url } : {})
+        }
+      })
+
+      // Log sends to Supabase for audience_reached_30d computation.
+      await logTriggerSends(db, trigger.id, userIds, sentAt)
+    } catch (e) {
+      logger.error(
+        { err: e, trigger: trigger.name },
+        'inactive-user notifications: error processing trigger'
+      )
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `sendInactiveUserNotifications` task in `apps/notifications` that runs hourly via the basekit `.tick()` loop
- Reads active trigger configs from the Supabase dashboard DB (`DASHBOARD_DB_URL`)
- Finds users who just crossed each trigger inactivity threshold using the discovery DB `plays` table
- Inserts a `notification` row into the discovery DB (existing push pipeline fans out to devices)
- Sets `notification_campaign_id = trigger.id` for open-rate attribution via Discovery
- Logs sends to `trigger_sends` in Supabase for `audience_reached_30d` computation
- Adds `/internal/inactive-users` HTTP endpoint (shared `findInactiveUsers` helper)

## New env var
`DASHBOARD_DB_URL` — Supabase direct pg connection string

## Test plan
- [ ] Set `DASHBOARD_DB_URL` in `apps/notifications` env
- [ ] Confirm hourly tick fires `sendInactiveUserNotifications`
- [ ] Verify `trigger_sends` rows appear in Supabase
- [ ] Verify push opens attributed to trigger campaign ID in Discovery

🤖 Generated with Claude
