### PR TITLE
fix(verified-notifications): listen on user_verified, drop history lookback

### DIFF
--- a/apps/verified-notifications/src/handlers/users.ts
+++ b/apps/verified-notifications/src/handlers/users.ts
@@ -14,24 +14,25 @@ type UserRow = {
   verified_with_tiktok?: boolean
 }
 
-// We resolve the "previous version" of the user directly from the versioned
-// `users` table — the row with the largest blocknumber strictly less than the
-// blocknumber that fired this NOTIFY. We used to walk Python's
-// `revert_blocks.prev_records` for this, but the new Go ETL indexer doesn't
-// populate revert_blocks, so any update to an already-verified user would look
-// like a brand-new verified signup and the channel would re-fire every time a
-// verified user touched their profile.
+// Fires off the dedicated `user_verified` NOTIFY channel, which the DB trigger
+// (api ddl/functions/notify_on_row.sql) emits ONLY on a genuine verification
+// transition — false -> true on an in-place update, or a brand-new row that
+// arrives already verified.
 //
-// Sourcing from `users` directly is also a strict improvement: revert_blocks is
-// going away with the Python indexer, and the versioned `users` table is the
-// real source of truth for what each row looked like before the change.
+// We used to listen on the `users` firehose and reconstruct the prior
+// verification state here (first from revert_blocks, then from a `users`
+// blocknumber lookback). Both broke under the Go ETL: it writes `users` in
+// place (one is_current row per user, no versioned history), so there is no
+// "previous" row to compare against and every profile edit by an
+// already-verified user re-fired. The transition is now detected in the
+// trigger via its OLD row, so this handler just announces — no lookback.
 export default async (
   app: App<AppData>,
   msg: { user_id: number; blocknumber: number }
 ): Promise<void> => {
   const { user_id, blocknumber } = msg
-  if (blocknumber === undefined) {
-    logger.warn('no block number returned')
+  if (user_id === undefined) {
+    logger.warn({ msg }, 'no user_id in user_verified payload')
     return
   }
 
@@ -58,31 +59,12 @@ export default async (
     return
   }
 
-  const prev = (await db('users')
-    .select('is_verified')
-    .where('user_id', '=', user_id)
-    .andWhere('blocknumber', '<', blocknumber)
-    .orderBy('blocknumber', 'desc')
-    .first()
-    .catch((err: unknown) => {
-      logger.error({ err, user_id, blocknumber }, 'users prev query')
-      return undefined
-    })) as { is_verified: boolean } | undefined
-
-  // Fire only on the actual false → true transition (or a brand-new user that
-  // arrives already verified). Re-firing on every is_current write to an
-  // already-verified user — which is what was happening prior to this rewrite
-  // — is exactly the noise we're trying to kill.
-  const newly_signed_up_verified = prev === undefined && current.is_verified
-  const became_verified =
-    prev !== undefined && !prev.is_verified && current.is_verified
-
-  logger.info(
-    { user_id, blocknumber, current, prev, newly_signed_up_verified, became_verified },
-    'user verification check'
-  )
-
-  if (!(newly_signed_up_verified || became_verified)) return
+  // Belt-and-suspenders: the trigger already gated on the transition, but guard
+  // against a verification that was reverted between the NOTIFY and this read.
+  if (!current.is_verified) {
+    logger.info({ user_id, blocknumber }, 'no longer verified, skipping')
+    return
+  }
 
   let source: string
   if (current.verified_with_twitter) source = 'twitter'

--- a/apps/verified-notifications/src/index.ts
+++ b/apps/verified-notifications/src/index.ts
@@ -35,7 +35,7 @@ const main = async (): Promise<void> => {
     })
 
   if (!shouldToggleOff('tracks')) app = app.listen('tracks', tracksHandler)
-  if (!shouldToggleOff('users')) app = app.listen('users', usersHandler)
+  if (!shouldToggleOff('user_verified')) app = app.listen('user_verified', usersHandler)
   if (!shouldToggleOff('usdc_purchases')) app = app.listen('usdc_purchases', purchasesHandler)
   if (!shouldToggleOff('artist_coins')) app = app.listen('artist_coins', artistCoinsHandler)
 


### PR DESCRIPTION
## Problem

The bot re-posts "now verified!" for **already-verified** users on every profile edit (~8/day, all noise).

#48 tried to fix this by reconstructing the user's prior verification state from the `users` table (`blocknumber < notify_blocknumber`). But the Go ETL writes `users` **in place** — one `is_current` row per user, no versioned history (verified on prod: **0** `is_current=false` rows). So the lookback always returns `undefined`, and `prev === undefined && current.is_verified` fires on every update. Same failure as the original revert_blocks approach, different source.

## Fix

Detect the transition where the data actually exists — in the DB trigger. The companion api PR adds a `user_verified` NOTIFY emitted **only** on a genuine `false -> true` transition (using the in-place update's `OLD` row). This PR:

- Switches the listener from the `users` firehose to `user_verified`.
- Drops the (now impossible) history lookback — the handler just loads the current row for `handle`/`source` and posts, with a belt-and-suspenders `is_verified` re-check against a transition that was reverted between NOTIFY and read.

## Dependency

**Requires** api PR that adds the `user_verified` channel (AudiusProject/api#887). The trigger must ship before/with this, or the new listener gets no events. Until then the existing `users` channel still exists but nothing listens on it for verifications.

## Test plan
- [ ] Verify a previously-unverified user → exactly one Slack post.
- [ ] Edit an already-verified user's profile → no post.
- [ ] New signup arriving already verified → exactly one post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)