### PR TITLE
notifications: point reward-cooldown "More Ways to Earn" CTA to /rewards

### DIFF
--- a/apps/notifications/src/email/notifications/preRendered/rewardInCooldown.ts
+++ b/apps/notifications/src/email/notifications/preRendered/rewardInCooldown.ts
@@ -873,12 +873,12 @@ export const email = ({
   <td class="stack-column-center" align="center">
   <div>
   <!--[if mso]>
-                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://audius.co/audio" style="height:48px;v-text-anchor:middle;width:420px;" fillcolor="#ffffff" strokecolor="#b5b4bb" strokeweight="1pt" arcsize="17%">
+                          <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="https://audius.co/rewards" style="height:48px;v-text-anchor:middle;width:420px;" fillcolor="#ffffff" strokecolor="#b5b4bb" strokeweight="1pt" arcsize="17%">
                           <w:anchorlock/>
                           <center style="white-space:nowrap;display:inline-block;text-align:center;color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;">More Ways to Earn</center>
                           </v:roundrect>
                       <![endif]-->
-  <a href="https://audius.co/audio" style="white-space:nowrap;background-color:#ffffff;border-radius:8px; border:1px solid #b5b4bb;display:inline-block;text-align:center;color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;line-height:48px;width:100%; -webkit-text-size-adjust:none;mso-hide:all;">More Ways to Earn</a>
+  <a href="https://audius.co/rewards" style="white-space:nowrap;background-color:#ffffff;border-radius:8px; border:1px solid #b5b4bb;display:inline-block;text-align:center;color:#3a3843;font-weight:600;font-family:Inter,Arial,sans-serif;font-size:18px;line-height:48px;width:100%; -webkit-text-size-adjust:none;mso-hide:all;">More Ways to Earn</a>
   </div>
   </td>
   </tr>


### PR DESCRIPTION
## Summary
- Update the "More Ways to Earn" CTA in the Reward-In-Cooldown email to link to `https://audius.co/rewards` instead of `https://audius.co/audio`.
- Applies to both the standard `<a>` button and the Outlook/MSO `<v:roundrect>` fallback in `preRendered/rewardInCooldown.ts`.

The challenge-image link (also `audius.co/audio`) was intentionally left unchanged, as only the "More Ways to Earn" link was requested.

## Test plan
- [ ] Render the Reward-In-Cooldown email and confirm the "More Ways to Earn" button navigates to audius.co/rewards in both standard and Outlook clients.

🤖 Generated with [Claude Code](https://claude.com/claude-code)