### PR TITLE
notifications: add GET /internal/inactive-users endpoint

### DIFF
--- a/apps/notifications/src/server/index.ts
+++ b/apps/notifications/src/server/index.ts
@@ -6,6 +6,7 @@ import { router as healthCheckRouter } from './routes/healthCheck'
 import { router as memStatsRouter } from './routes/memStats'
 import { createSendNotificationRouter } from './routes/sendNotification'
 import { createSendWelcomeEmailRouter } from './routes/sendWelcomeEmail'
+import { createInactiveUsersRouter } from './routes/inactiveUsers'
 
 const DEFAULT_PORT = 6000
 
@@ -31,6 +32,10 @@ export class Server {
       this.app.use(
         '/internal/send-welcome-email',
         createSendWelcomeEmailRouter(identityDb)
+      )
+      this.app.use(
+        '/internal/inactive-users',
+        createInactiveUsersRouter(discoveryDb)
       )
     }
 

--- a/apps/notifications/src/server/routes/inactiveUsers.ts
+++ b/apps/notifications/src/server/routes/inactiveUsers.ts
@@ -1,0 +1,57 @@
+import { Router, Request, Response } from 'express'
+import { Knex } from 'knex'
+import { logger } from '../../logger'
+import { findInactiveUsers } from '../../tasks/inactiveUserNotifications'
+
+const parsePositiveInt = (value: unknown): number | null => {
+  if (value == null || value === '') return null
+  const n = Number(value)
+  if (!Number.isInteger(n) || n <= 0) return null
+  return n
+}
+
+export function createInactiveUsersRouter(discoveryDb: Knex): Router {
+  const router = Router()
+  router.get('/', async (req: Request, res: Response) => {
+    const secret = process.env.ANNOUNCEMENT_SEND_SECRET
+    if (!secret) {
+      res.status(503).json({
+        error:
+          'Inactive-users is disabled: set ANNOUNCEMENT_SEND_SECRET in env to enable.'
+      })
+      return
+    }
+    const auth = req.headers.authorization
+    if (auth !== `Bearer ${secret}`) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+
+    const hours = parsePositiveInt(req.query.hours)
+    const windowHours = parsePositiveInt(req.query.windowHours)
+    const limit = parsePositiveInt(req.query.limit)
+    if (hours === null || windowHours === null || limit === null) {
+      res.status(400).json({
+        error:
+          'hours, windowHours and limit are required positive integers'
+      })
+      return
+    }
+
+    try {
+      const userIds = await findInactiveUsers(
+        discoveryDb,
+        hours,
+        windowHours,
+        limit
+      )
+      res.json({ userIds })
+    } catch (e) {
+      logger.error(e, 'inactive-users query failed')
+      res.status(500).json({
+        error: e instanceof Error ? e.message : 'Inactive-users query failed'
+      })
+    }
+  })
+  return router
+}


### PR DESCRIPTION
## What

Adds `GET /internal/inactive-users` to the notification service (`apps/notifications`).

- Accepts `?hours=<n>&windowHours=<n>&limit=<n>` (all required positive integers).
- Calls the existing `findInactiveUsers(discoveryDb, hours, windowHours, limit)` from `src/tasks/inactiveUserNotifications.ts`.
- Returns `{ userIds: number[] }`.
- Secured with the same Bearer `ANNOUNCEMENT_SEND_SECRET` auth as the other `/internal` routes (503 when the secret is unset, 401 on mismatch).
- Mounted in `src/server/index.ts` alongside the other internal routes (only when `discoveryDb` is available).

## Why

Exposes the inactive-user query over HTTP so the re-engagement caller can fetch candidate user IDs without re-implementing the query.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Manual: `curl -H "Authorization: Bearer $ANNOUNCEMENT_SEND_SECRET" "localhost:6000/internal/inactive-users?hours=168&windowHours=24&limit=100"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)