### PR TITLE
trending-challenge-rewards: fix empty Slack trending digest after discovery→Go migration

### DIFF
--- a/apps/trending-challenge-rewards/src/__tests__/trending.test.ts
+++ b/apps/trending-challenge-rewards/src/__tests__/trending.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import { Knex } from 'knex'
+import { queryTopTrending, composeTweet } from '../trending'
+
+// Builds a chainable knex mock. Each `db(table)` call returns a fresh builder
+// that records its `whereIn` args and resolves `.first()` / `.limit()`.
+const makeMockDb = (latestWeek: string, rows: any[]) => {
+  const builders: any[] = []
+  const db: any = jest.fn(() => {
+    const q: any = {
+      whereIn: jest.fn(() => q),
+      where: jest.fn(() => q),
+      orderBy: jest.fn(() => q),
+      first: jest.fn(() => Promise.resolve({ week: latestWeek })),
+      limit: jest.fn(() => Promise.resolve(rows))
+    }
+    builders.push(q)
+    return q
+  })
+  return { db: db as unknown as Knex, builders }
+}
+
+describe('queryTopTrending', () => {
+  it('matches both the new bare and legacy prefixed trending types', async () => {
+    const { db, builders } = makeMockDb('2026-06-05', [
+      { user_id: 1, id: '1', rank: 1, type: 'TRACKS' }
+    ])
+
+    await queryTopTrending(db, '2026-06-05')
+
+    // First two builders are the tracks query (latest-week + rows),
+    // next two are the underground query.
+    expect(builders[0].whereIn).toHaveBeenCalledWith('type', [
+      'TRACKS',
+      'TrendingType.TRACKS'
+    ])
+    expect(builders[2].whereIn).toHaveBeenCalledWith('type', [
+      'UNDERGROUND_TRACKS',
+      'TrendingType.UNDERGROUND_TRACKS'
+    ])
+  })
+
+  it('selects the most recent week on or before the requested date', async () => {
+    const { db, builders } = makeMockDb('2026-05-29', [
+      { user_id: 1, id: '1', rank: 1, type: 'TRACKS' }
+    ])
+
+    const [tracks] = await queryTopTrending(db, '2026-06-05')
+
+    // latest-week builder filters week <= requested and orders desc
+    expect(builders[0].where).toHaveBeenCalledWith('week', '<=', '2026-06-05')
+    expect(builders[0].orderBy).toHaveBeenCalledWith('week', 'desc')
+    // rows builder pins to the resolved latest week
+    expect(builders[1].where).toHaveBeenCalledWith('week', '=', '2026-05-29')
+    expect(tracks).toHaveLength(1)
+  })
+
+  it('returns an empty list when no week is available', async () => {
+    const db: any = jest.fn(() => {
+      const q: any = {
+        whereIn: jest.fn(() => q),
+        where: jest.fn(() => q),
+        orderBy: jest.fn(() => q),
+        first: jest.fn(() => Promise.resolve(undefined)),
+        limit: jest.fn(() => Promise.resolve([]))
+      }
+      return q
+    })
+
+    const [tracks, underground] = await queryTopTrending(
+      db as unknown as Knex,
+      '2026-06-05'
+    )
+
+    expect(tracks).toEqual([])
+    expect(underground).toEqual([])
+  })
+})
+
+describe('composeTweet', () => {
+  it('renders handles ordered by rank under the title/week header', () => {
+    const out = composeTweet('Top 10 Trending Tracks 🔥', '2026-06-05', [
+      { handle: '@second', rank: 2 },
+      { handle: '@first', rank: 1 }
+    ])
+
+    expect(out).toContain('Top 10 Trending Tracks 🔥 (2026-06-05)')
+    expect(out.indexOf('@first')).toBeLessThan(out.indexOf('@second'))
+  })
+})

--- a/apps/trending-challenge-rewards/src/trending.ts
+++ b/apps/trending-challenge-rewards/src/trending.ts
@@ -6,10 +6,17 @@ import { WebClient } from '@slack/web-api'
 import moment from 'moment'
 import { Table, TrendingResults, Users } from '@pedalboard/storage'
 
-enum TrendingTypes {
-  Tracks = 'TrendingType.TRACKS',
-  UndergroundTracks = 'TrendingType.UNDERGROUND_TRACKS'
-}
+// trending_results.type values to match. The trending-challenge computation
+// was ported from the discovery-provider (Python) to the Go API in api#835
+// (merged 2026-05-28), which dropped the "TrendingType." prefix from the type
+// column (e.g. "TrendingType.TRACKS" -> "TRACKS"). Match both the new bare
+// values and the legacy prefixed ones so the digest works during/after the
+// migration regardless of which system wrote the row.
+const TRENDING_TYPES_TRACKS = ['TRACKS', 'TrendingType.TRACKS']
+const TRENDING_TYPES_UNDERGROUND = [
+  'UNDERGROUND_TRACKS',
+  'TrendingType.UNDERGROUND_TRACKS'
+]
 
 type TrendingEntry = {
   handle: string // instagram or discovery
@@ -69,19 +76,27 @@ export const queryTopTrending = async (
   discoveryDb: Knex,
   week: string
 ): Promise<TrendingResults[][]> => {
-  const tracks = await discoveryDb<TrendingResults>(Table.TrendingResults)
-    .where('type', '=', TrendingTypes.Tracks)
-    .where('week', '=', week)
-    .orderBy('rank')
-    .limit(10)
+  // Pick the most recent available week on or before the requested date rather
+  // than requiring an exact `week = today` match. This mirrors the discovery
+  // API (GET /v1/tracks/trending/winners) and keeps the digest resilient to
+  // timezone/timing skew between this cron and the trending job that writes
+  // the rows.
+  const queryForType = async (types: string[]) => {
+    const latest = await discoveryDb<TrendingResults>(Table.TrendingResults)
+      .whereIn('type', types)
+      .where('week', '<=', week)
+      .orderBy('week', 'desc')
+      .first()
+    if (latest === undefined) return []
+    return discoveryDb<TrendingResults>(Table.TrendingResults)
+      .whereIn('type', types)
+      .where('week', '=', latest.week)
+      .orderBy('rank')
+      .limit(10)
+  }
 
-  const undergroundTracks = await discoveryDb<TrendingResults>(
-    Table.TrendingResults
-  )
-    .where('type', '=', TrendingTypes.UndergroundTracks)
-    .where('week', '=', week)
-    .orderBy('rank')
-    .limit(10)
+  const tracks = await queryForType(TRENDING_TYPES_TRACKS)
+  const undergroundTracks = await queryForType(TRENDING_TYPES_UNDERGROUND)
 
   return [tracks, undergroundTracks]
 }


### PR DESCRIPTION
## Problem

The automated **Top 10 Trending Tracks 🔥** and **Trending Underground** Slack digests started posting only the date header (`Top 10 Trending Tracks 🔥 (2026-06-05)`) with a **blank track list**.

## Root cause

[api#835](https://github.com/AudiusProject/api/pull/835) (merged 2026-05-28) ported the trending-challenge computation from the discovery-provider (Python) into a new Go poll-based job (`jobs/challenges/trending.go`). The new writer inserts `trending_results` rows with:

- `type = "TRACKS"` / `"UNDERGROUND_TRACKS"` — the `TrendingType.` prefix was **dropped**
- `version = "pnagD"` (was `"TrendingVersion.ML51L"`)
- `week = ` the Friday run date (unchanged — *not* the problem)

`queryTopTrending` filtered on the legacy `'TrendingType.TRACKS'` string, so it matched **zero rows** for every week written after the migration → the digest rendered empty. The reward **disbursement** path is unaffected (it reads `user_challenges`, not `trending_results`), so payouts continued normally — this was purely the informational digest.

## Fix

- Match **both** the new bare type values and the legacy prefixed ones via `whereIn`, so the digest works during and after the migration regardless of which system wrote the row.
- Select the **most recent available week on or before the requested date** instead of requiring an exact `week = today` match — mirrors the discovery API (`GET /v1/tracks/trending/winners`) and absorbs timezone/timing skew between this cron (Fri 12:15 PT) and the trending job (Fri UTC).
- Add unit tests covering type matching, week selection, the empty-result case, and `composeTweet` ordering.

## ⚠️ Related follow-up (api repo)

The api's own `/v1/tracks/trending/winners` and `/v1/tracks/trending/underground/winners` endpoints still query the legacy `'TrendingType.TRACKS'` string (see `api/v1_tracks_trending_winners.go:46`), while the new writer emits `'TRACKS'`. Those endpoints are likely returning empty too and should be reconciled separately in the api repo.

## Test plan

- [x] `npx jest src/__tests__/trending.test.ts` — 4/4 pass
- [x] `tsc --noEmit` clean for `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)