### PR TITLE
anti-abuse-oracle: assert antiAbuseWalletPubkey in /health_check test

### DIFF
--- a/apps/anti-abuse-oracle/src/__tests__/server.test.tsx
+++ b/apps/anti-abuse-oracle/src/__tests__/server.test.tsx
@@ -80,7 +80,8 @@ vi.mock('keccak256', () => ({
 }))
 
 vi.mock('secp256k1', () => ({
-  ecdsaSign: vi.fn(() => ({ signature: new Uint8Array(64).fill(2), recid: 1 }))
+  ecdsaSign: vi.fn(() => ({ signature: new Uint8Array(64).fill(2), recid: 1 })),
+  publicKeyCreate: vi.fn(() => new Uint8Array(65).fill(3))
 }))
 
 const setBasicAuthEnv = () => {
@@ -104,7 +105,10 @@ describe('server', () => {
       const { app } = await import('../server')
       const res = await app.request('/health_check')
       expect(res.status).toBe(200)
-      expect(await res.json()).toEqual({ status: 'ok' })
+      expect(await res.json()).toEqual({
+        status: 'ok',
+        antiAbuseWalletPubkey: expect.any(String)
+      })
     })
   })
 


### PR DESCRIPTION
## What

`/health_check` now returns `antiAbuseWalletPubkey` (added in #39), but the test in `server.test.tsx` still asserted the response equaled `{ status: 'ok' }`, which fails the deep-equality check.

This PR:
- Mocks `secp256k1.publicKeyCreate` so server init can derive the wallet pubkey under test.
- Updates the `/health_check` assertion to expect `{ status: 'ok', antiAbuseWalletPubkey: expect.any(String) }`.

## Testing

`npx vitest run src/__tests__/server.test.tsx` (Node 24) — all 11 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)