### PR TITLE
notifications: add notificationTypes channel selector to /internal/send-notification

### DIFF
--- a/apps/notifications/src/processNotifications/mappers/announcement.ts
+++ b/apps/notifications/src/processNotifications/mappers/announcement.ts
@@ -81,13 +81,21 @@ export class Announcement extends BaseNotification<AnnouncementNotificationRow> 
       this.identityDB,
       userIds
     )
+    // Absent channels (older rows / non-dashboard callers) default to 'both'.
+    const channels = this.notification.data.notification_channels ?? 'both'
+    const sendPush = channels === 'push' || channels === 'both'
+    const sendEmail = channels === 'email' || channels === 'both'
     for (const userId of userIds) {
-      await this.broadcastPushNotificationAnnouncements(
-        userId,
-        userNotificationSettings,
-        isBrowserPushEnabled
-      )
-      await this.broadcastEmailAnnouncements(userId, userNotificationSettings)
+      if (sendPush) {
+        await this.broadcastPushNotificationAnnouncements(
+          userId,
+          userNotificationSettings,
+          isBrowserPushEnabled
+        )
+      }
+      if (sendEmail) {
+        await this.broadcastEmailAnnouncements(userId, userNotificationSettings)
+      }
     }
   }
 

--- a/apps/notifications/src/server/routes/sendNotification.ts
+++ b/apps/notifications/src/server/routes/sendNotification.ts
@@ -1,8 +1,14 @@
 import { Router, Request, Response } from 'express'
 import { Knex } from 'knex'
 import { logger } from '../../logger'
+import { NotificationChannel } from '../../types/notifications'
 
 const containsHtml = (value: string): boolean => /<[^>]*>/.test(value)
+const NOTIFICATION_CHANNELS: readonly NotificationChannel[] = [
+  'email',
+  'push',
+  'both'
+]
 const normalizeRoute = (value: string): string | null => {
   const input = value.trim()
   if (!input) return null
@@ -34,11 +40,29 @@ export function createSendNotificationRouter(discoveryDb: Knex): Router {
       res.status(401).json({ error: 'Unauthorized' })
       return
     }
-    const { title, body, image_url, route, userIds, notification_campaign_id } =
-      req.body
+    const {
+      title,
+      body,
+      image_url,
+      route,
+      userIds,
+      notification_campaign_id,
+      notificationTypes
+    } = req.body
     if (!title || !body || !Array.isArray(userIds) || userIds.length === 0) {
       res.status(400).json({
         error: 'Missing required fields: title, body, userIds (non-empty array)'
+      })
+      return
+    }
+    // Default to 'both' so existing callers that omit notificationTypes are unaffected.
+    const channels: NotificationChannel =
+      notificationTypes == null ? 'both' : notificationTypes
+    if (!NOTIFICATION_CHANNELS.includes(channels)) {
+      res.status(400).json({
+        error: `Invalid notificationTypes. Use one of: ${NOTIFICATION_CHANNELS.join(
+          ', '
+        )}`
       })
       return
     }
@@ -102,7 +126,8 @@ export function createSendNotificationRouter(discoveryDb: Knex): Router {
           push_body: bodyText,
           ...(normalizedRoute ? { route: normalizedRoute } : {}),
           ...(imageUrlText ? { image_url: imageUrlText } : {}),
-          ...(campaignIdRaw ? { notification_campaign_id: campaignIdRaw } : {})
+          ...(campaignIdRaw ? { notification_campaign_id: campaignIdRaw } : {}),
+          notification_channels: channels
         }
       })
       logger.info(

--- a/apps/notifications/src/types/notifications.ts
+++ b/apps/notifications/src/types/notifications.ts
@@ -248,6 +248,9 @@ export type TrendingUndergroundNotification = {
   time_range: string
 }
 
+/** Which delivery channels an announcement should fire. Defaults to `both`. */
+export type NotificationChannel = 'email' | 'push' | 'both'
+
 export type AnnouncementNotification = {
   title: string
   short_description: string
@@ -258,6 +261,8 @@ export type AnnouncementNotification = {
   image_url?: string
   /** First-party campaign id (e.g. notifications-dashboard `announcements.id`). */
   notification_campaign_id?: string
+  /** Delivery channels to fire. Absent is treated as `both` for back-compat. */
+  notification_channels?: NotificationChannel
 }
 
 export type USDCPurchaseBuyerNotification = {


### PR DESCRIPTION
## What

Adds a `notificationTypes` parameter to the `POST /internal/send-notification` endpoint so callers can choose whether an announcement fires **email only**, **push only**, or **both**.

- Request field: `notificationTypes` — one of `"email"`, `"push"`, `"both"`.
- **Defaults to `"both"`** when omitted, so existing callers (the notifications dashboard, mobile tests) are unaffected.
- Invalid values are rejected with `400`.

## How it threads through

The endpoint doesn't send inline — it inserts a `notification` row whose `data` JSON is later picked up by the `Announcement` mapper. So the channel selection rides along on the row:

1. **[`sendNotification.ts`](apps/notifications/src/server/routes/sendNotification.ts)** — parses + validates `notificationTypes`, persists it as `data.notification_channels`.
2. **[`announcement.ts`](apps/notifications/src/processNotifications/mappers/announcement.ts)** — reads `data.notification_channels` (defaulting to `both` for absent/legacy rows) and gates `broadcastPushNotificationAnnouncements` / `broadcastEmailAnnouncements` per user.
3. **[`notifications.ts`](apps/notifications/src/types/notifications.ts)** — adds `NotificationChannel` type and the optional `notification_channels` field on `AnnouncementNotification`.

## Notes

- `push` covers both mobile (SNS) push and browser web-push, since both are driven by `broadcastPushNotificationAnnouncements`.
- Per-user notification settings (`shouldSendPush` / `shouldSendEmail`) still apply on top of the channel filter.

## Verification

- `npm run typecheck` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)