### PR TITLE
notifications: enable SendGrid click tracking on notification emails

### DIFF
--- a/apps/notifications/src/email/notifications/sendEmail.ts
+++ b/apps/notifications/src/email/notifications/sendEmail.ts
@@ -103,6 +103,16 @@ export const sendNotificationEmail = async ({
       subject: emailSubject,
       asm: {
         groupId: NOTIFICATION_EMAIL_UNSUBSCRIBE_GROUP_ID
+      },
+      // Explicitly enable click tracking so SendGrid rewrites links and emits
+      // `click` events (consumed by the notifications-dashboard webhook for
+      // email engagement analytics) rather than relying on the account-global
+      // toggle. Open tracking is disabled: Apple Mail Privacy Protection
+      // pre-fetches the open pixel for ~half of traffic, making opens noise —
+      // clicks are the trustworthy email signal.
+      trackingSettings: {
+        clickTracking: { enable: true, enableText: true },
+        openTracking: { enable: false }
       }
     }
 


### PR DESCRIPTION
## Summary
Explicitly enable **click tracking** on notification emails so SendGrid rewrites links and emits `click` events. Previously `sendEmail.ts` set no `trackingSettings`, so click data depended on the SendGrid account-global toggle rather than code.

```ts
trackingSettings: {
  clickTracking: { enable: true, enableText: true },
  openTracking: { enable: false },
}
```

## Why
The notifications-dashboard already has the full email-analytics pipeline: a signature-verified SendGrid Event Webhook → `email_events` → hourly aggregation into `announcements.email_clicked` + a "top clicked links" UI. That pipeline is fed by SendGrid `click` events, which only fire when click tracking rewrites links. Making it explicit here removes the implicit dependency on account settings.

**Open tracking is disabled on purpose:** Apple Mail Privacy Protection pre-fetches the open pixel for ~half of traffic, making opens noise. The dashboard already ignores email opens and uses click rate as the trustworthy signal.

This is the send-side half of email-click parity with push opens; the dashboard ingestion/aggregation/UI already exists.

## Testing
- `tsc --noEmit` clean for `apps/notifications/src` (pre-existing `@types/babel__traverse` node_modules errors are unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)