### PR TITLE
fix(trending-challenge-rewards): inline sol_reward_disbursements, drop dropped view

### DIFF
--- a/apps/trending-challenge-rewards/src/queries.ts
+++ b/apps/trending-challenge-rewards/src/queries.ts
@@ -34,7 +34,10 @@ export const getChallengesDisbursementsUserbanks = async (
       'u.specifier',
       'c.slot'
     )
-    .leftJoin('v_challenge_disbursements as c', function () {
+    // Slot comes straight from sol_reward_disbursements (one row per
+    // challenge_id+specifier); the v_challenge_disbursements compatibility
+    // view was dropped in api migration 0212.
+    .leftJoin('sol_reward_disbursements as c', function () {
       this.on('u.specifier', '=', 'c.specifier').andOn(
         'u.challenge_id',
         '=',
@@ -66,7 +69,10 @@ export const getChallengesDisbursementsUserbanksFriendly = async (
       'u.completed_blocknumber',
       'c.slot'
     )
-    .leftJoin('v_challenge_disbursements as c', function () {
+    // Slot comes straight from sol_reward_disbursements (one row per
+    // challenge_id+specifier); the v_challenge_disbursements compatibility
+    // view was dropped in api migration 0212.
+    .leftJoin('sol_reward_disbursements as c', function () {
       this.on('u.specifier', '=', 'c.specifier').andOn(
         'u.challenge_id',
         '=',


### PR DESCRIPTION
## Summary

The trending disburser's summary queries (`getChallengesDisbursementsUserbanks` and `getChallengesDisbursementsUserbanksFriendly` in `queries.ts`) `leftJoin` the `v_challenge_disbursements` compatibility view. That view was **dropped in api migration `0212`** (the API routes were refactored to inline the join — see `api/v1_challenges_disbursements.go`). So every `/disburse` run now throws in the post-payout summary step:

```
relation "v_challenge_disbursements" does not exist  (42P01)
```

Payouts still succeed (they happen before the summary), but the exception fires **before `chat.postMessage`**, so the Slack confirmation table never posts.

## Change

Join `sol_reward_disbursements` directly on `(challenge_id, specifier)` for `slot`, in both queries. `sol_reward_disbursements` has exactly one row per `(challenge_id, specifier)`, so the slot resolution is identical. The dropped view's only extra was a `recipient_eth_address → users` join to resolve `user_id`, which these queries never used — they already join `users` via `user_challenges.user_id`.

No other references to the view remain in the app.

## Why this happened (context)

Surfaced while manually disbursing the corrected `2026-06-05` trending/underground winners. All 23 rows paid out fine, but no Slack summary posted because of this 42P01. Recreating the view is a viable stopgap, but it resurrects something the api repo deliberately dropped — this decouples the disburser from it for good.

## Test plan

- [x] String-literal table swap inside `.leftJoin(table, joinFn)` — structurally identical, type-unchanged (full monorepo typecheck not run here due to local dep skew; no errors reference `queries.ts`).
- [ ] On next `/disburse <date>`, the summary query runs and the Slack table posts (no 42P01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)