### PR TITLE
perf(notifications): make DM polling timestamp predicates sargable

### DIFF
--- a/apps/notifications/src/tasks/dmNotifications.ts
+++ b/apps/notifications/src/tasks/dmNotifications.ts
@@ -83,14 +83,20 @@ async function getUnreadMessages(
     .from('chat_message')
     .innerJoin('chat_member', 'chat_message.chat_id', 'chat_member.chat_id')
     .where('chat_message.blast_id', null)
-    // Javascript dates are limited to 3 decimal places (milliseconds). Truncate the postgresql timestamp to match.
+    // Javascript dates are limited to 3 decimal places (milliseconds). Move
+    // truncation to the bounds so chat_message.created_at remains indexable.
     .whereRaw(
-      `date_trunc('milliseconds', chat_message.created_at) > greatest(chat_member.last_active_at, ?::timestamp)`,
+      `chat_message.created_at >= date_trunc('milliseconds', ?::timestamp) + interval '1 millisecond'`,
       [minTimestamp.toISOString()]
     )
-    .andWhereRaw(`date_trunc('milliseconds', chat_message.created_at) <= ?`, [
-      maxTimestamp.toISOString()
-    ])
+    .andWhereRaw(
+      `chat_message.created_at < date_trunc('milliseconds', ?::timestamp) + interval '1 millisecond'`,
+      [maxTimestamp.toISOString()]
+    )
+    .andWhereRaw(
+      `chat_message.created_at >= date_trunc('milliseconds', greatest(chat_member.last_active_at, ?::timestamp)) + interval '1 millisecond'`,
+      [minTimestamp.toISOString()]
+    )
     .andWhereRaw('chat_message.user_id != chat_member.user_id')
 }
 
@@ -117,14 +123,20 @@ async function getUnreadReactions(
     .joinRaw(
       'join chat_member on chat_member.chat_id = chat_message.chat_id and chat_member.user_id = chat_message.user_id'
     )
-    // Javascript dates are limited to 3 decimal places (milliseconds). Truncate the postgresql timestamp to match.
+    // Javascript dates are limited to 3 decimal places (milliseconds). Move
+    // truncation to the bounds so chat_message_reactions.updated_at remains
+    // indexable.
     .whereRaw(
-      `date_trunc('milliseconds', chat_message_reactions.updated_at) > greatest(chat_member.last_active_at, ?)`,
+      `chat_message_reactions.updated_at >= date_trunc('milliseconds', ?::timestamp) + interval '1 millisecond'`,
       [minTimestamp.toISOString()]
     )
     .andWhereRaw(
-      `date_trunc('milliseconds', chat_message_reactions.updated_at) <= ? `,
+      `chat_message_reactions.updated_at < date_trunc('milliseconds', ?::timestamp) + interval '1 millisecond'`,
       [maxTimestamp.toISOString()]
+    )
+    .andWhereRaw(
+      `chat_message_reactions.updated_at >= date_trunc('milliseconds', greatest(chat_member.last_active_at, ?::timestamp)) + interval '1 millisecond'`,
+      [minTimestamp.toISOString()]
     )
     .andWhereRaw('chat_message_reactions.user_id != chat_member.user_id')
 }


### PR DESCRIPTION
## Summary
- move millisecond truncation from `chat_message.created_at` / `chat_message_reactions.updated_at` onto the cursor bounds
- preserve JS millisecond cursor semantics with exclusive lower and upper timestamp bounds
- keep per-member `last_active_at` filtering while allowing the global timestamp range to use timestamp-leading indexes

## Read-only prod evidence
- current DM message query plan scans ~1.98M `chat_message` rows and ~522k `chat_member` rows for a one-hour window with only 4 non-blast messages
- equivalent sargable message-window shape plans as an index-driven nested loop instead of the parallel hash join/seq scans
- current DM reaction query plan cost was ~40k; equivalent sargable shape cost was ~712 even before the API timestamp-index PR lands
- long-horizon `pg_stat_statements` shows ~33M calls for each notifier query, with ~7.17M total seconds for messages and ~5.48M total seconds for reactions

## Test
- `/Users/ray/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node node_modules/prettier/bin-prettier.js --check apps/notifications/src/tasks/dmNotifications.ts`
- `/Users/ray/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node apps/notifications/node_modules/typescript/bin/tsc --noEmit -p apps/notifications/tsconfig.json`
- `git diff --check`