### PR TITLE
Handle missing fingerprint table in AAO

### DIFF
--- a/apps/anti-abuse-oracle/src/__tests__/identity.test.ts
+++ b/apps/anti-abuse-oracle/src/__tests__/identity.test.ts
@@ -7,10 +7,14 @@ type SqlCall = {
 
 const sqlCalls: SqlCall[] = []
 let nextResult: unknown[] = []
+let nextError: unknown
 
 const mockSqlFn = vi.fn(
   (strings: readonly string[], ...values: unknown[]): Promise<unknown[]> => {
     sqlCalls.push({ strings, values })
+    if (nextError) {
+      return Promise.reject(nextError)
+    }
     return Promise.resolve(nextResult)
   }
 )
@@ -31,6 +35,7 @@ describe('identity', () => {
   beforeEach(() => {
     sqlCalls.length = 0
     nextResult = []
+    nextError = undefined
     mockSqlFn.mockClear()
   })
 
@@ -52,6 +57,18 @@ describe('identity', () => {
     expect(call.strings.join('?')).toContain('"Fingerprints"')
   })
 
+  it('userFingerprints returns no rows when the Fingerprints table is missing', async () => {
+    nextError = { code: '42P01' }
+    const { userFingerprints } = await import('../identity')
+    await expect(userFingerprints(42)).resolves.toEqual([])
+  })
+
+  it('userFingerprints throws non-Fingerprints-table errors', async () => {
+    nextError = { code: '53300' }
+    const { userFingerprints } = await import('../identity')
+    await expect(userFingerprints(42)).rejects.toEqual({ code: '53300' })
+  })
+
   it('useFingerprintDeviceCount returns maxUserCount from the first row', async () => {
     nextResult = [{ maxUserCount: 7 }]
     const { useFingerprintDeviceCount } = await import('../identity')
@@ -64,6 +81,20 @@ describe('identity', () => {
     nextResult = [{ maxUserCount: null }]
     const { useFingerprintDeviceCount } = await import('../identity')
     expect(await useFingerprintDeviceCount(99)).toBe(0)
+  })
+
+  it('useFingerprintDeviceCount falls back to 0 when the Fingerprints table is missing', async () => {
+    nextError = { code: '42P01' }
+    const { useFingerprintDeviceCount } = await import('../identity')
+    await expect(useFingerprintDeviceCount(99)).resolves.toBe(0)
+  })
+
+  it('useFingerprintDeviceCount throws non-Fingerprints-table errors', async () => {
+    nextError = { code: '53300' }
+    const { useFingerprintDeviceCount } = await import('../identity')
+    await expect(useFingerprintDeviceCount(99)).rejects.toEqual({
+      code: '53300'
+    })
   })
 
   it('useEmailDeliverable looks up by wallet and returns isEmailDeliverable', async () => {

--- a/apps/anti-abuse-oracle/src/identity.ts
+++ b/apps/anti-abuse-oracle/src/identity.ts
@@ -10,18 +10,32 @@ type FingerprintCount = {
   userIds: number[]
 }
 
+const isUndefinedTableError = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: string }).code === '42P01'
+
 export async function userFingerprints(userId: number) {
-  const rows: FingerprintCount[] = await sql`
-    select
-      "visitorId" as "fingerprint",
-      count(distinct "userId") as "userCount",
-      array_agg("userId") as "userIds"
-    from "Fingerprints"
-    where "visitorId" in (
-      select "visitorId" from "Fingerprints" where "userId" = ${userId}
-    )
-    group by 1 order by 2 desc limit 90;
-  `
+  let rows: FingerprintCount[]
+  try {
+    rows = await sql`
+      select
+        "visitorId" as "fingerprint",
+        count(distinct "userId") as "userCount",
+        array_agg("userId") as "userIds"
+      from "Fingerprints"
+      where "visitorId" in (
+        select "visitorId" from "Fingerprints" where "userId" = ${userId}
+      )
+      group by 1 order by 2 desc limit 90;
+    `
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return []
+    }
+    throw error
+  }
 
   for (const row of rows) {
     row.userIds.sort()
@@ -31,20 +45,28 @@ export async function userFingerprints(userId: number) {
 }
 
 export async function useFingerprintDeviceCount(userId: number) {
-  const rows = await sql`
-    SELECT
-        MAX("userCount") AS "maxUserCount"
-    FROM (
-        SELECT
-            "visitorId",
-            COUNT(DISTINCT "userId") AS "userCount"
-        FROM "Fingerprints"
-        WHERE "visitorId" IN (
-            SELECT "visitorId" FROM "Fingerprints" WHERE "userId" = ${userId}
-        )
-        GROUP BY "visitorId"
-    ) t;
-  `
+  let rows
+  try {
+    rows = await sql`
+      SELECT
+          MAX("userCount") AS "maxUserCount"
+      FROM (
+          SELECT
+              "visitorId",
+              COUNT(DISTINCT "userId") AS "userCount"
+          FROM "Fingerprints"
+          WHERE "visitorId" IN (
+              SELECT "visitorId" FROM "Fingerprints" WHERE "userId" = ${userId}
+          )
+          GROUP BY "visitorId"
+      ) t;
+    `
+  } catch (error) {
+    if (isUndefinedTableError(error)) {
+      return 0
+    }
+    throw error
+  }
   return rows[0].maxUserCount ?? 0
 }
 


### PR DESCRIPTION
## Summary
- Treat missing identity-service `Fingerprints` table as no fingerprint signal in AAO
- Keep non-`42P01` identity DB errors failing loudly
- Add identity helper tests for the fallback and error propagation paths

## Verification
- `node ../../node_modules/vitest/vitest.mjs run` from `apps/anti-abuse-oracle`: 29 tests passed
- Docker build passed for `audius/anti-abuse-oracle:aao-fingerprint-fallback-20260615-1106`
- Deployed hotfix image to prod `anti-abuse-oracle`; rollout completed 1/1 ready
- Post-deploy AAO logs show successful attestation 200s instead of missing `Fingerprints` 500s

## Production note
- Live deployment currently runs `audius/anti-abuse-oracle:aao-fingerprint-fallback-20260615-1106` at digest `sha256:98a8ca3cfad8e613ece540b85378c6889e4e3220ac27c5765f89084362147d84`
