### PR TITLE
Fix DAMM v2 claim fee pool lookup

### DIFF
--- a/apps/solana-relay/src/routes/launchpad/claim_fees.ts
+++ b/apps/solana-relay/src/routes/launchpad/claim_fees.ts
@@ -211,7 +211,7 @@ export const claimFees = async (
       try {
         const dammV2ClaimFeeTxs = await getDammV2PoolTxs(
           connection,
-          tokenMint as string,
+          pools.damm_v2_pool,
           ownerWallet,
           receiverWallet,
           ownerWalletAudioATA


### PR DESCRIPTION
## Summary
- Fix DAMM v2 claim-fee transaction construction to pass the indexed `damm_v2_pool` address into `getDammV2PoolTxs` instead of the artist token mint.
- Keep `@meteora-ag/cp-amm-sdk` pinned at the existing version to avoid expanding this PR into quote/swap SDK behavior changes.

## Notes
- I checked npm and the latest published `@meteora-ag/cp-amm-sdk` is still `1.4.3`; the announced DAMM v2 `0.2.2` SDK package referenced by Meteora is not published as `1.4.4` yet. That should be a follow-up once it is available.

## Test Plan
- `npm run lint --workspace=@pedalboard/solana-relay`
- `npm exec --workspace=@pedalboard/solana-relay -- vitest run`