### PR TITLE
Fix trending rewards week selection and winner handles

### DIFF
--- a/apps/trending-challenge-rewards/src/__tests__/queries.test.ts
+++ b/apps/trending-challenge-rewards/src/__tests__/queries.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, jest } from '@jest/globals'
+import { Knex } from 'knex'
+import { getTrendingChallenges } from '../queries'
+
+describe('getTrendingChallenges', () => {
+  it('selects the latest trending challenge by specifier date, not completed block', async () => {
+    const rows = [
+      {
+        challenge_id: 'tt',
+        specifier: '2026-06-26:1',
+        completed_blocknumber: 120145840
+      }
+    ]
+    const q: any = {
+      from: jest.fn(() => q),
+      where: jest.fn(() => q),
+      whereNotNull: jest.fn(() => q),
+      whereRaw: jest.fn(() => q),
+      orderByRaw: jest.fn(() => q),
+      orderBy: jest.fn(() => q),
+      limit: jest.fn(() => Promise.resolve(rows))
+    }
+    const db: any = {
+      select: jest.fn(() => q)
+    }
+
+    const result = await getTrendingChallenges(
+      db as unknown as Knex,
+      '2026-06-26'
+    )
+
+    expect(q.where).toHaveBeenCalledWith('challenge_id', '=', 'tt')
+    expect(q.whereRaw).toHaveBeenCalledWith(
+      "split_part(specifier, ':', 1) <= ?",
+      ['2026-06-26']
+    )
+    expect(q.orderByRaw).toHaveBeenCalledWith(
+      "split_part(specifier, ':', 1) DESC"
+    )
+    expect(q.orderBy).toHaveBeenCalledWith('specifier', 'asc')
+    expect(result).toBe(rows)
+  })
+})

--- a/apps/trending-challenge-rewards/src/__tests__/trending.test.ts
+++ b/apps/trending-challenge-rewards/src/__tests__/trending.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, jest } from '@jest/globals'
 import { Knex } from 'knex'
-import { queryTopTrending, composeTweet } from '../trending'
+import { queryTopTrending, queryHandles, composeTweet } from '../trending'
 
 // Builds a chainable knex mock. Each `db(table)` call returns a fresh builder
 // that records its `whereIn` args and resolves `.first()` / `.limit()`.
@@ -74,6 +74,35 @@ describe('queryTopTrending', () => {
 
     expect(tracks).toEqual([])
     expect(underground).toEqual([])
+  })
+})
+
+describe('queryHandles', () => {
+  it('uses twitter handles from discovery users with audius handle fallback', async () => {
+    const q: any = {
+      select: jest.fn(() => q),
+      whereIn: jest.fn(() => q),
+      andWhere: jest.fn(() =>
+        Promise.resolve([
+          { user_id: 1, handle: 'first', twitter_handle: 'twitter_first' },
+          { user_id: 2, handle: 'second', twitter_handle: null },
+          { user_id: 3, handle: 'third', twitter_handle: '@third_prefixed' }
+        ])
+      )
+    }
+    const db: any = jest.fn(() => q)
+
+    const handles = await queryHandles(db as unknown as Knex, [
+      { user_id: 1 },
+      { user_id: 2 },
+      { user_id: 3 }
+    ] as any[])
+
+    expect(q.select).toHaveBeenCalledWith('user_id', 'handle', 'twitter_handle')
+    expect(q.whereIn).toHaveBeenCalledWith('user_id', [1, 2, 3])
+    expect(handles.get(1)).toBe('@twitter_first')
+    expect(handles.get(2)).toBe('@/second')
+    expect(handles.get(3)).toBe('@third_prefixed')
   })
 })
 

--- a/apps/trending-challenge-rewards/src/queries.ts
+++ b/apps/trending-challenge-rewards/src/queries.ts
@@ -20,6 +20,8 @@ export type ChallengeDisbursementUserbankFriendly = {
   slot: null | string
 }
 
+const TRENDING_REWARD_IDS = ['tt', 'tut']
+
 export const getChallengesDisbursementsUserbanks = async (
   discoveryDb: Knex,
   specifier: string
@@ -52,6 +54,7 @@ export const getChallengesDisbursementsUserbanks = async (
       'users.wallet'
     )
     .where('u.specifier', '~', specifier)
+    .whereIn('u.challenge_id', TRENDING_REWARD_IDS)
     .where('users.is_current', true)
 
 export const getChallengesDisbursementsUserbanksFriendly = async (
@@ -81,6 +84,7 @@ export const getChallengesDisbursementsUserbanksFriendly = async (
     })
     .join('users', 'users.user_id', '=', 'u.user_id')
     .where('u.specifier', '~', specifier)
+    .whereIn('u.challenge_id', TRENDING_REWARD_IDS)
     .where('users.is_current', true)
     .orderBy('u.challenge_id')
     .orderBy('u.specifier')
@@ -124,14 +128,18 @@ export const getChallengesDisbursementsUserbanksFriendlyEnsureSlots = async (
 }
 
 export const getTrendingChallenges = async (
-  discoveryDb: Knex
+  discoveryDb: Knex,
+  maxSpecifierDate: string
 ): Promise<UserChallenges[]> =>
   discoveryDb
     .select()
     .from<UserChallenges>(Table.UserChallenges)
     // only use tt because we just need a trending challenge
     .where('challenge_id', '=', 'tt')
-    .orderBy('completed_blocknumber', 'desc')
+    .whereNotNull('completed_blocknumber')
+    .whereRaw("split_part(specifier, ':', 1) <= ?", [maxSpecifierDate])
+    .orderByRaw("split_part(specifier, ':', 1) DESC")
+    .orderBy('specifier', 'asc')
     .limit(100)
 
 // queries for trending challenges by a particular date in order to get the starting block number
@@ -145,5 +153,6 @@ export const getTrendingChallengesByDate = async (
     // only use tt because we just need a trending challenge
     .where('challenge_id', '=', 'tt')
     .where('specifier', 'like', `${specifierPrefix}%`)
+    .whereNotNull('completed_blocknumber')
+    .orderBy('specifier', 'asc')
     .limit(100)
-

--- a/apps/trending-challenge-rewards/src/rewards.ts
+++ b/apps/trending-challenge-rewards/src/rewards.ts
@@ -12,6 +12,7 @@ import { formatDisbursementTable } from './slack'
 import { discoveryDb } from './utils'
 import { ChallengeId } from '@audius/sdk'
 import axios from 'axios'
+import moment from 'moment'
 
 type Challenge = {
   challenge_id: string
@@ -61,8 +62,12 @@ export const onDisburse = async (
   } else {
     const response = await getTrendingChallengesByDate(db, targetSpecifier)
     const challenge = response[0]
+    if (challenge === undefined)
+      return new Err(`no challenges found for ${targetSpecifier}`)
+    if (challenge.completed_blocknumber === null)
+      return new Err(`completed block number is null ${challenge}`)
     specifier = challenge.specifier
-    completedBlock = challenge.completed_blocknumber! - 1
+    completedBlock = challenge.completed_blocknumber - 1
   }
   console.log(
     'completed blockNumber = ',
@@ -79,7 +84,7 @@ export const onDisburse = async (
     console.log('endpoint = ', apiEndpoint)
     const toDisburse: Challenge[] = []
     for (const challengeId of TRENDING_REWARD_IDS) {
-      const url = `${apiEndpoint}/v1/challenges/undisbursed?challenge_id=${challengeId}&completed_blocknumber=${completedBlock}`
+      const url = `${apiEndpoint}/v1/challenges/undisbursed?challenge_id=${challengeId}&completed_blocknumber=${completedBlock}&limit=500`
       console.log('fetching undisbursed challenges from url = ', url)
       // Fetch all undisbursed challenges
       const res = await axios.get(url)
@@ -186,7 +191,10 @@ export const onDisburse = async (
 export const findStartingBlock = async (
   db: Knex
 ): Promise<Result<[number, string], string>> => {
-  const challenges = await getTrendingChallenges(db)
+  const challenges = await getTrendingChallenges(
+    db,
+    moment().format('YYYY-MM-DD')
+  )
   const firstChallenge = challenges[0]
   if (firstChallenge === undefined)
     return new Err(`no challenges found ${challenges}`)

--- a/apps/trending-challenge-rewards/src/trending.ts
+++ b/apps/trending-challenge-rewards/src/trending.ts
@@ -1,7 +1,7 @@
 import { App } from '@pedalboard/basekit'
 import { Knex } from 'knex'
 import { SharedData } from './config'
-import { discoveryDb, identityDb } from './utils'
+import { discoveryDb } from './utils'
 import { WebClient } from '@slack/web-api'
 import moment from 'moment'
 import { Table, TrendingResults, Users } from '@pedalboard/storage'
@@ -19,7 +19,7 @@ const TRENDING_TYPES_UNDERGROUND = [
 ]
 
 type TrendingEntry = {
-  handle: string // instagram or discovery
+  handle: string // twitter or discovery
   rank: number
 }
 
@@ -36,12 +36,8 @@ export const announceTopTrending = async (
     week
   )
 
-  const trackHandles = await queryHandles(discoveryDb, identityDb, tracks)
-  const undergroundHandles = await queryHandles(
-    discoveryDb,
-    identityDb,
-    undergroundTracks
-  )
+  const trackHandles = await queryHandles(discoveryDb, tracks)
+  const undergroundHandles = await queryHandles(discoveryDb, undergroundTracks)
 
   const trackEntries = assembleEntries(trackHandles, tracks)
   const undergroundEntries = assembleEntries(
@@ -103,32 +99,29 @@ export const queryTopTrending = async (
 
 export const queryHandles = async (
   discoveryDb: Knex,
-  identityDb: Knex,
   trendingResults: TrendingResults[]
 ): Promise<Map<number, string>> => {
   const blockchainUserIds = trendingResults.map((res) => res.user_id)
-  const userHandles = await identityDb('Users')
-    .select('handle', 'blockchainUserId')
-    .whereIn('blockchainUserId', blockchainUserIds)
-  const handles = userHandles.map((handle) => handle.handle)
-  const instagramHandles = await discoveryDb<Users>(Table.Users)
-    .select('handle', 'instagram_handle')
-    .whereIn('handle', handles)
+  if (blockchainUserIds.length === 0) return new Map()
+
+  const users = await discoveryDb<Users>(Table.Users)
+    .select('user_id', 'handle', 'twitter_handle')
+    .whereIn('user_id', blockchainUserIds)
     .andWhere('is_current', true)
+  const usersById = new Map(users.map((user) => [user.user_id, user]))
   const handleMap = new Map<number, string>()
   for (const userId of blockchainUserIds) {
-    const userHandle = userHandles.find(
-      (handle) => handle.blockchainUserId === userId
-    )
-    const instagramHandle = instagramHandles.find(
-      (handle) =>
-        handle.handle === userHandle.handle && !!handle.instagram_handle
-    )
-    if (instagramHandle === undefined)
-      handleMap.set(userId, `@/${userHandle.handle}`)
-    else {
-      handleMap.set(userId, `@${instagramHandle.instagram_handle}`)
+    const user = usersById.get(userId)
+    if (user === undefined) {
+      console.warn(`no current discovery user found for user_id ${userId}`)
+      handleMap.set(userId, `@/user-${userId}`)
+      continue
     }
+    const twitterHandle = user.twitter_handle?.trim().replace(/^@/, '')
+    handleMap.set(
+      userId,
+      twitterHandle ? `@${twitterHandle}` : `@/${user.handle}`
+    )
   }
   return handleMap
 }


### PR DESCRIPTION
## Summary
- resolve trending winner announcement handles from Discovery users, using twitter_handle first with Audius handle fallback
- select scheduled disbursements by latest specifier date instead of max completed_blocknumber
- fetch the full undisbursed challenge page and restrict disbursement reports to tt/tut
- add regression coverage for handle resolution and date-based disbursement selection

## Test plan
- npm test -- --runInBand src/__tests__/trending.test.ts src/__tests__/queries.test.ts
- npm run build
- npm run lint (passes with warnings only)