### PR TITLE
ci: deploy changed pedalboard plugins on main

### DIFF
--- a/.github/actions/setup-services-matrix/action.yml
+++ b/.github/actions/setup-services-matrix/action.yml
@@ -1,10 +1,19 @@
 name: 'Setup Services Matrix'
 description: 'Load services configuration and output as matrix for workflows'
 
+inputs:
+  services:
+    description: 'Optional JSON array of services to include'
+    required: false
+    default: ''
+
 outputs:
   services:
     description: 'JSON array of services for matrix strategy'
     value: ${{ steps.load-services.outputs.services }}
+  has_services:
+    description: 'Whether the services matrix contains at least one service'
+    value: ${{ steps.load-services.outputs.has_services }}
 
 runs:
   using: 'composite'
@@ -12,6 +21,43 @@ runs:
     - name: Load services configuration
       id: load-services
       shell: bash
+      env:
+        INPUT_SERVICES: ${{ inputs.services }}
       run: |
-        SERVICES=$(cat .github/config/services.json | jq -c .)
-        echo "services=$SERVICES" >> $GITHUB_OUTPUT
+        if [ -n "$INPUT_SERVICES" ]; then
+          SERVICES="$INPUT_SERVICES"
+        else
+          SERVICES=$(jq -c . .github/config/services.json)
+        fi
+
+        if ! jq -e 'type == "array" and all(.[]; type == "string")' <<< "$SERVICES" > /dev/null; then
+          echo "Error: services must be a JSON array of strings" >&2
+          exit 1
+        fi
+
+        UNKNOWN_SERVICES=$(
+          jq -r -n \
+            --argjson services "$SERVICES" \
+            --slurpfile allowed .github/config/services.json \
+            '$services[] as $service | select(($allowed[0] | index($service)) | not) | $service'
+        )
+
+        if [ -n "$UNKNOWN_SERVICES" ]; then
+          echo "Error: unknown service(s):" >&2
+          echo "$UNKNOWN_SERVICES" >&2
+          echo "Allowed services:" >&2
+          jq -r '.[]' .github/config/services.json >&2
+          exit 1
+        fi
+
+        SERVICES=$(
+          jq -c -n \
+            --argjson services "$SERVICES" \
+            --slurpfile allowed .github/config/services.json \
+            '[$allowed[0][] as $service | select($services | index($service)) | $service]'
+        )
+
+        HAS_SERVICES=$(jq -r 'length > 0' <<< "$SERVICES")
+
+        echo "services=$SERVICES" >> "$GITHUB_OUTPUT"
+        echo "has_services=$HAS_SERVICES" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -7,6 +7,11 @@ on:
         description: 'Tag to apply to images'
         required: true
         type: string
+      services:
+        description: 'JSON array of services to build. Defaults to all services.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   # Generate services list for matrix
@@ -15,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       services: ${{ steps.setup-services.outputs.services }}
+      has_services: ${{ steps.setup-services.outputs.has_services }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -22,10 +28,13 @@ jobs:
       - name: Setup services matrix
         id: setup-services
         uses: ./.github/actions/setup-services-matrix
+        with:
+          services: ${{ inputs.services }}
 
   # Build AMD64 images  
   build-amd64:
     name: Build ${{ matrix.service }} (amd64)
+    if: ${{ needs.setup.outputs.has_services == 'true' }}
     runs-on: ubuntu-latest
     needs: setup
     strategy:
@@ -47,6 +56,7 @@ jobs:
   # Build ARM64 images
   build-arm64:
     name: Build ${{ matrix.service }} (arm64)
+    if: ${{ needs.setup.outputs.has_services == 'true' }}
     runs-on: ubuntu-24.04-arm
     needs: setup
     strategy:
@@ -68,6 +78,7 @@ jobs:
   # Create multiarch manifests
   create-multiarch:
     name: Create multiarch manifest for ${{ matrix.service }}
+    if: ${{ needs.setup.outputs.has_services == 'true' }}
     runs-on: ubuntu-latest
     needs: [setup, build-amd64, build-arm64]
     strategy:
@@ -95,4 +106,3 @@ jobs:
             "$AMD64_TAG" \
             "$ARM64_TAG" \
             --tag "$MULTIARCH_TAG"
-          

--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -9,36 +9,71 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # First build the services
-  build:
-    uses: ./.github/workflows/build-services.yml
-    with:
-      tag: ${{ github.sha }}
-    secrets: inherit
-
-  # Setup services matrix
-  setup:
-    name: Setup services matrix
+  # Detect the services with app-local changes in this push.
+  changes:
+    name: Detect changed services
     runs-on: ubuntu-latest
-    needs: build
     outputs:
       services: ${{ steps.setup-services.outputs.services }}
+      has_services: ${{ steps.setup-services.outputs.has_services }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      
-      - name: Setup services matrix
+
+      - name: Detect changed apps
+        id: changed-apps
+        uses: dorny/paths-filter@v4
+        with:
+          base: ${{ github.ref }}
+          filters: |
+            backfill-audio-analyses:
+              - 'apps/backfill-audio-analyses/**'
+            notifications:
+              - 'apps/notifications/**'
+            verified-notifications:
+              - 'apps/verified-notifications/**'
+            publish-scheduled-releases:
+              - 'apps/publish-scheduled-releases/**'
+            crm:
+              - 'apps/crm/**'
+            archiver:
+              - 'apps/archiver/**'
+            staking:
+              - 'apps/staking/**'
+            trending-challenge-rewards:
+              - 'apps/trending-challenge-rewards/**'
+            solana-relay:
+              - 'apps/solana-relay/**'
+            sla-auditor:
+              - 'apps/sla-auditor/**'
+            anti-abuse-oracle:
+              - 'apps/anti-abuse-oracle/**'
+
+      - name: Setup changed services matrix
         id: setup-services
         uses: ./.github/actions/setup-services-matrix
+        with:
+          services: ${{ steps.changed-apps.outputs.changes }}
 
-  # Then retag the multiarch images as edge
+  # First build the changed services
+  build:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_services == 'true' }}
+    uses: ./.github/workflows/build-services.yml
+    with:
+      tag: ${{ github.sha }}
+      services: ${{ needs.changes.outputs.services }}
+    secrets: inherit
+
+  # Then retag the changed multiarch images as edge
   retag-edge:
     name: Retag ${{ matrix.service }} as edge
     runs-on: ubuntu-latest
-    needs: setup
+    needs: [changes, build]
+    if: ${{ needs.changes.outputs.has_services == 'true' }}
     strategy:
       matrix:
-        service: ${{ fromJson(needs.setup.outputs.services) }}
+        service: ${{ fromJson(needs.changes.outputs.services) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,4 +90,3 @@ jobs:
           SOURCE_TAG="${REPO}:${{ github.sha }}"
           EDGE_TAG="${REPO}:edge"
           docker buildx imagetools create "$SOURCE_TAG" --tag "$EDGE_TAG"
-          

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,7 @@ npm run docker:verified-notifications
 
 ### CI/CD
 
-The GitHub Action automatically builds all apps on push to `main`/`develop` or PR to `main`. Each app is built in parallel as a separate job, so failures are isolated.
+The GitHub Action automatically builds changed apps on push to `main` and all apps on PRs to `main`. Each app is built in parallel as a separate job, so failures are isolated.
 
 ## Available Commands
 
@@ -91,7 +91,8 @@ npm run docker:archiver            # Build archiver
 ### CI/CD
 - Each app builds as a separate GitHub Actions job
 - Failures are isolated - one app failing doesn't affect others
-- Runs on push to `main`/`develop` and PRs to `main`
+- Pushes to `main` build and publish only apps with changes under their `apps/<app>` directory
+- PRs to `main` build all configured apps
 - Can be manually triggered via workflow dispatch
 
 ## Troubleshooting
@@ -130,5 +131,5 @@ npm run docker:archiver            # Build archiver
 ## Adding New Apps
 
 1. Create app directory in `apps/`
-2. Add entry to Makefile (or it will be auto-discovered)
-3. Add build job to `.github/workflows/build-apps.yml`
+2. Add an npm docker script if you want a named local shortcut
+3. Add the app name to `.github/config/services.json` if CI should build and publish it


### PR DESCRIPTION
## Summary
- detect changed app/plugin directories on pushes to `main` with `dorny/paths-filter`
- pass the changed service list into the reusable Docker build workflow
- build and retag only changed services as `edge`, while PR builds still default to all configured services
- update build docs for the changed deploy behavior

## Testing
- `git diff --check`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build-services.yml .github/workflows/edge.yml .github/workflows/latest.yml .github/workflows/pr.yml .github/workflows/test.yml`