### PR TITLE
chore(ci): build only changed services, amd64-only, on PRs

### DIFF
--- a/.github/workflows/build-services.yml
+++ b/.github/workflows/build-services.yml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: ''
+      build_arm64:
+        description: 'Also build arm64 + multi-arch manifest. PRs pass false (amd64 compile check only) to halve build cost; releases leave it true.'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   # Generate services list for matrix
@@ -56,7 +61,7 @@ jobs:
   # Build ARM64 images
   build-arm64:
     name: Build ${{ matrix.service }} (arm64)
-    if: ${{ needs.setup.outputs.has_services == 'true' }}
+    if: ${{ inputs.build_arm64 && needs.setup.outputs.has_services == 'true' }}
     runs-on: ubuntu-24.04-arm
     needs: setup
     strategy:
@@ -78,7 +83,7 @@ jobs:
   # Create multiarch manifests
   create-multiarch:
     name: Create multiarch manifest for ${{ matrix.service }}
-    if: ${{ needs.setup.outputs.has_services == 'true' }}
+    if: ${{ inputs.build_arm64 && needs.setup.outputs.has_services == 'true' }}
     runs-on: ubuntu-latest
     needs: [setup, build-amd64, build-arm64]
     strategy:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,9 +4,67 @@ on:
   pull_request:
     branches: [ main ]
 
+# Cancel an in-flight PR build when the PR is updated with new commits.
+concurrency:
+  group: pr-build-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
+  # Only build the services whose app code changed in this PR, mirroring the
+  # change-detection that edge.yml already uses on main. A PR touching one
+  # service no longer rebuilds all of them.
+  changes:
+    name: Detect changed services
+    runs-on: ubuntu-latest
+    outputs:
+      services: ${{ steps.setup-services.outputs.services }}
+      has_services: ${{ steps.setup-services.outputs.has_services }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect changed apps
+        id: changed-apps
+        uses: dorny/paths-filter@v4
+        with:
+          filters: |
+            backfill-audio-analyses:
+              - 'apps/backfill-audio-analyses/**'
+            notifications:
+              - 'apps/notifications/**'
+            verified-notifications:
+              - 'apps/verified-notifications/**'
+            publish-scheduled-releases:
+              - 'apps/publish-scheduled-releases/**'
+            crm:
+              - 'apps/crm/**'
+            archiver:
+              - 'apps/archiver/**'
+            staking:
+              - 'apps/staking/**'
+            trending-challenge-rewards:
+              - 'apps/trending-challenge-rewards/**'
+            solana-relay:
+              - 'apps/solana-relay/**'
+            sla-auditor:
+              - 'apps/sla-auditor/**'
+            anti-abuse-oracle:
+              - 'apps/anti-abuse-oracle/**'
+
+      - name: Setup changed services matrix
+        id: setup-services
+        uses: ./.github/actions/setup-services-matrix
+        with:
+          services: ${{ steps.changed-apps.outputs.changes }}
+
+  # Compile-check the changed services on amd64 only. PRs don't need arm64 or a
+  # pushed multi-arch manifest — edge.yml produces those on merge to main.
   build:
+    needs: changes
+    if: ${{ needs.changes.outputs.has_services == 'true' }}
     uses: ./.github/workflows/build-services.yml
     with:
       tag: ${{ github.sha }}
+      services: ${{ needs.changes.outputs.services }}
+      build_arm64: false
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded test runs when a PR is updated with new commits.
+concurrency:
+  group: tests-${{ github.head_ref }}
+  cancel-in-progress: true
+
 jobs:
   anti-abuse-oracle:
     name: anti-abuse-oracle


### PR DESCRIPTION
## Goal
Cut GitHub Actions spend. PR builds were the main cost driver in this repo.

## Changes
**`pr.yml`** previously rebuilt **all 13 services for both amd64 and arm64, plus 13 multi-arch manifest jobs, on every PR** — regardless of what changed. Now it:
- **detects changed services** via `dorny/paths-filter` (mirrors the change-detection `edge.yml` already uses on main) — a PR touching one service builds only that service;
- **builds amd64 only** as a compile check — arm64 + multi-arch manifests are still produced by `edge.yml` on merge to main, which is what releases consume;
- **cancels superseded builds** when a PR is updated.

**`build-services.yml`** gains a `build_arm64` input (default `true`) to support the amd64-only PR path. `edge.yml` and `latest.yml` are unchanged (still full multi-arch).

**`test.yml`** gains `cancel-in-progress` concurrency.

## Estimated savings
Typical PR goes from **26 builds + 13 manifest jobs → 1 amd64 build**. Combined with the change-detection, this removes the large majority of PR build minutes (incl. all PR arm64 runners). Rough estimate **~$8–12/mo** of the ~$19/mo.

## Note
Relay app removal already landed (`89b0fbf`); the repo still ships ~12 active services, so CI is trimmed rather than gutted. Per-app path filtering matches `edge.yml`'s existing behavior (a change to a shared `packages/*` lib won't rebuild dependent services on PR — same limitation as main today; flag if you want shared-lib changes to fan out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)