### PR TITLE
Route notification images through API content gateway

### DIFF
--- a/apps/notifications/README.md
+++ b/apps/notifications/README.md
@@ -91,6 +91,7 @@ To find `targetARN`: query identity DB table `NotificationDeviceTokens`, e.g. `s
 - `NOTIFICATIONS_LOG_REMOTE_CONFIG_SNAPSHOT` – set to **`1`** to log a one-shot **`Remote config snapshot (Optimizely)`** at startup (all push flags + raw vs effective)
 - `GIT_COMMIT`, `IMAGE_TAG`, `BUILD_TIME` – (optional) deploy metadata for logs and `/health_check`; see Dockerfile build-args
 - `SENDGRID_API_KEY` – email
+- `NOTIFICATIONS_CONTENT_NODE_ENDPOINT` – (optional) stable public `/content` gateway for email images; default **`https://api.audius.co`**
 - `ANNOUNCEMENT_SEND_SECRET` – (optional) if set, `POST /internal/send-notification` requires `Authorization: Bearer <this value>` (used by notifications-dashboard). Optional body field **`notification_campaign_id`** is stored on the notification row and included on mobile push payloads.
 
 ### Push pipeline logs

--- a/apps/notifications/src/__tests__/contentNodeEnv.test.ts
+++ b/apps/notifications/src/__tests__/contentNodeEnv.test.ts
@@ -1,0 +1,40 @@
+import { getContentNode } from '../utils/env'
+import { formatImageUrl } from '../utils/format'
+
+describe('content node env', () => {
+  const oldNotificationsEndpoint =
+    process.env.NOTIFICATIONS_CONTENT_NODE_ENDPOINT
+  const oldContentEndpoint = process.env.CONTENT_NODE_ENDPOINT
+
+  afterEach(() => {
+    if (oldNotificationsEndpoint === undefined) {
+      delete process.env.NOTIFICATIONS_CONTENT_NODE_ENDPOINT
+    } else {
+      process.env.NOTIFICATIONS_CONTENT_NODE_ENDPOINT = oldNotificationsEndpoint
+    }
+
+    if (oldContentEndpoint === undefined) {
+      delete process.env.CONTENT_NODE_ENDPOINT
+    } else {
+      process.env.CONTENT_NODE_ENDPOINT = oldContentEndpoint
+    }
+  })
+
+  it('uses the API content gateway by default', () => {
+    delete process.env.NOTIFICATIONS_CONTENT_NODE_ENDPOINT
+    delete process.env.CONTENT_NODE_ENDPOINT
+
+    expect(getContentNode()).toBe('https://api.audius.co')
+    expect(formatImageUrl('image-cid', 150)).toBe(
+      'https://api.audius.co/content/image-cid/150x150.jpg'
+    )
+  })
+
+  it('allows notification-specific gateway overrides', () => {
+    process.env.NOTIFICATIONS_CONTENT_NODE_ENDPOINT =
+      'https://images.example.com/'
+    process.env.CONTENT_NODE_ENDPOINT = 'https://generic.example.com'
+
+    expect(getContentNode()).toBe('https://images.example.com')
+  })
+})

--- a/apps/notifications/src/__tests__/mappings/addTrackToPlaylist.test.ts
+++ b/apps/notifications/src/__tests__/mappings/addTrackToPlaylist.test.ts
@@ -80,7 +80,7 @@ describe('Add track to playlist notification', () => {
           playlistId: 55,
           type: 'AddTrackToPlaylist'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/artistRemixContestEnded.test.ts
+++ b/apps/notifications/src/__tests__/mappings/artistRemixContestEnded.test.ts
@@ -68,7 +68,7 @@ describe('Artist Remix Contest Ended Notification', () => {
           type: 'ArtistRemixContestEnded',
           entityId: 12345
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/artistRemixContestEndingSoon.test.ts
+++ b/apps/notifications/src/__tests__/mappings/artistRemixContestEndingSoon.test.ts
@@ -77,7 +77,7 @@ describe('Artist Remix Contest Ending Soon Notification', () => {
           entityId: 12345,
           entityUserId: 99
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/artistRemixContestSubmissions.test.ts
+++ b/apps/notifications/src/__tests__/mappings/artistRemixContestSubmissions.test.ts
@@ -69,7 +69,7 @@ describe('Artist Remix Contest Submissions Notification', () => {
           eventId: 999,
           milestone: 1
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })
@@ -119,7 +119,7 @@ describe('Artist Remix Contest Submissions Notification', () => {
           eventId: 999,
           milestone: 10
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/comment.test.ts
+++ b/apps/notifications/src/__tests__/mappings/comment.test.ts
@@ -88,7 +88,7 @@ describe('Comment Notification', () => {
           entityId: 10,
           commentId: 1
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/commentMention.test.ts
+++ b/apps/notifications/src/__tests__/mappings/commentMention.test.ts
@@ -93,7 +93,7 @@ describe('Comment Mention Notification', () => {
           entityId: 1,
           commentId: 1
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/commentReaction.test.ts
+++ b/apps/notifications/src/__tests__/mappings/commentReaction.test.ts
@@ -97,7 +97,7 @@ describe('Comment Reaction Notification', () => {
           userIds: [2],
           commentId: 1
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })
@@ -246,7 +246,7 @@ describe('Comment Reaction Notification', () => {
           commentId: 1
         },
         imageUrl:
-          'https://creatornode2.audius.co/content/contest-hash/150x150.jpg'
+          'https://api.audius.co/content/contest-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/commentThread.test.ts
+++ b/apps/notifications/src/__tests__/mappings/commentThread.test.ts
@@ -100,7 +100,7 @@ describe('Comment Thread Notification', () => {
           userIds: [2],
           commentId: 2
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/cosign.test.ts
+++ b/apps/notifications/src/__tests__/mappings/cosign.test.ts
@@ -84,7 +84,7 @@ describe('Cosign Notification', () => {
           id: 'timestamp:1589373217:group_id:cosign:parent_track10:original_track:20',
           type: 'RemixCosign'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/create.test.ts
+++ b/apps/notifications/src/__tests__/mappings/create.test.ts
@@ -78,7 +78,7 @@ describe('Create Notification', () => {
           userId: 1,
           entityType: 'Track'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })
@@ -138,7 +138,7 @@ describe('Create Notification', () => {
           userId: 1,
           entityType: 'Track'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
 
@@ -162,7 +162,7 @@ describe('Create Notification', () => {
           userId: 1,
           entityType: 'Track'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })
@@ -260,7 +260,7 @@ describe('Create Notification', () => {
           userId: 1,
           entityType: 'Playlist'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })
@@ -350,7 +350,7 @@ describe('Create Notification', () => {
           userId: 1,
           entityType: 'Album'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/fanClubTextPost.test.ts
+++ b/apps/notifications/src/__tests__/mappings/fanClubTextPost.test.ts
@@ -72,7 +72,7 @@ describe('Fan Club Text Post Notification', () => {
           commentId: 100
         }),
         imageUrl:
-          'https://creatornode2.audius.co/content/artist-pfp-hash/150x150.jpg'
+          'https://api.audius.co/content/artist-pfp-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/fanRemixContestEnded.test.ts
+++ b/apps/notifications/src/__tests__/mappings/fanRemixContestEnded.test.ts
@@ -78,7 +78,7 @@ describe('Fan Remix Contest Ended Notification', () => {
           entityId: 12345,
           entityUserId: 99
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/fanRemixContestEndingSoon.test.ts
+++ b/apps/notifications/src/__tests__/mappings/fanRemixContestEndingSoon.test.ts
@@ -77,7 +77,7 @@ describe('Fan Remix Contest Ending Soon Notification', () => {
           entityId: 12345,
           entityUserId: 99
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/fanRemixContestStarted.test.ts
+++ b/apps/notifications/src/__tests__/mappings/fanRemixContestStarted.test.ts
@@ -77,7 +77,7 @@ describe('Fan Remix Contest Started Notification', () => {
           entityId: 12345,
           entityUserId: 99
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/fanRemixContestWinnersSelected.test.ts
+++ b/apps/notifications/src/__tests__/mappings/fanRemixContestWinnersSelected.test.ts
@@ -78,7 +78,7 @@ describe('Fan Remix Contest Winners Selected Notification', () => {
           entityId: 12345,
           entityUserId: 99
         }),
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       })
     )
   })

--- a/apps/notifications/src/__tests__/mappings/milestone.test.ts
+++ b/apps/notifications/src/__tests__/mappings/milestone.test.ts
@@ -173,7 +173,7 @@ describe('Milestone Notification', () => {
           id: 'timestamp:1589373217:group_id:milestone:TRACK_REPOST_COUNT:id:2:threshold:10',
           type: 'MilestoneRepost'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/remix.test.ts
+++ b/apps/notifications/src/__tests__/mappings/remix.test.ts
@@ -72,7 +72,7 @@ describe('Remix Notification', () => {
           id: 'timestamp:1589373217:group_id:remix:track:20:parent_track:10',
           type: 'RemixCreate'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/repostOfRepost.test.ts
+++ b/apps/notifications/src/__tests__/mappings/repostOfRepost.test.ts
@@ -118,7 +118,7 @@ describe('Repost Of Repost Notification', () => {
           entityId: 10,
           userIds: [3]
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     ])
   })
@@ -148,7 +148,7 @@ describe('Repost Of Repost Notification', () => {
           entityType: 'Playlist',
           entityId: 10
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     ])
   })
@@ -178,7 +178,7 @@ describe('Repost Of Repost Notification', () => {
           entityType: 'Album',
           entityId: 10
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     ])
   })

--- a/apps/notifications/src/__tests__/mappings/save.test.ts
+++ b/apps/notifications/src/__tests__/mappings/save.test.ts
@@ -68,7 +68,7 @@ describe('Save Notification', () => {
           type: 'Favorite',
           userIds: [2]
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })
@@ -112,7 +112,7 @@ describe('Save Notification', () => {
           type: 'Favorite',
           userIds: [2]
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/saveOfRepost.test.ts
+++ b/apps/notifications/src/__tests__/mappings/saveOfRepost.test.ts
@@ -119,7 +119,7 @@ describe('Save Of Repost Notification', () => {
           entityType: 'Track',
           entityId: 10
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     ])
   })
@@ -149,7 +149,7 @@ describe('Save Of Repost Notification', () => {
           entityType: 'Playlist',
           entityId: 10
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     ])
   })
@@ -179,7 +179,7 @@ describe('Save Of Repost Notification', () => {
           entityType: 'Album',
           entityId: 10
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     ])
   })

--- a/apps/notifications/src/__tests__/mappings/tastemaker.test.ts
+++ b/apps/notifications/src/__tests__/mappings/tastemaker.test.ts
@@ -89,7 +89,7 @@ describe('Tastemaker Notification', () => {
           entityType: 'Track',
           entityId: 3
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/trendingTrack.test.ts
+++ b/apps/notifications/src/__tests__/mappings/trendingTrack.test.ts
@@ -85,7 +85,7 @@ describe('Trending Track Notification', () => {
           id: 'timestamp:1589373217:group_id:trending:time_range:week:genre:all:rank:3:track_id:10:timestamp:1677261600',
           type: 'TrendingTrack'
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/trendingUnderground.test.ts
+++ b/apps/notifications/src/__tests__/mappings/trendingUnderground.test.ts
@@ -78,7 +78,7 @@ describe('Trending Underground Notification', () => {
         title: "📈 You're Trending",
         body: `track_title_10 is #3 on Underground Trending right now!`,
         data: {},
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
   })

--- a/apps/notifications/src/__tests__/mappings/usdcPurchaseSeller.test.ts
+++ b/apps/notifications/src/__tests__/mappings/usdcPurchaseSeller.test.ts
@@ -95,7 +95,7 @@ describe('USDC Purchase Seller', () => {
           type: 'USDCPurchaseSeller',
           entityId: 10
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
 
@@ -250,7 +250,7 @@ describe('USDC Purchase Seller', () => {
           type: 'USDCPurchaseSeller',
           entityId: 15
         },
-        imageUrl: 'https://creatornode2.audius.co/content/test-hash/150x150.jpg'
+        imageUrl: 'https://api.audius.co/content/test-hash/150x150.jpg'
       }
     )
 

--- a/apps/notifications/src/email/notifications/renderEmail.ts
+++ b/apps/notifications/src/email/notifications/renderEmail.ts
@@ -116,25 +116,21 @@ const getUserProfileUrl = (user: UserResource) => {
 }
 
 const getTrackCoverArt = (track: TrackResource) => {
-  // Match getUserProfileUrl: when the owner's creator_node_endpoint is missing
-  // we still want a working URL, so fall back to the stable CN gateway.
-  const primaryEndpoint =
-    track.creator_node_endpoint?.split(',')[0]?.trim() || getContentNode()
+  const contentNode = getContentNode()
   if (track.cover_art_sizes) {
-    return `${primaryEndpoint}/content/${track.cover_art_sizes}/1000x1000.jpg`
+    return `${contentNode}/content/${track.cover_art_sizes}/1000x1000.jpg`
   } else if (track.cover_art) {
-    return `${primaryEndpoint}/content/${track.cover_art}`
+    return `${contentNode}/content/${track.cover_art}`
   }
   return DEFAULT_TRACK_COVER_ART_URL
 }
 
 const getPlaylistImage = (playlist: PlaylistResource) => {
-  const primaryEndpoint =
-    playlist.creator_node_endpoint?.split(',')[0]?.trim() || getContentNode()
+  const contentNode = getContentNode()
   if (playlist.playlist_image_sizes_multihash) {
-    return `${primaryEndpoint}/content/${playlist.playlist_image_sizes_multihash}/1000x1000.jpg`
+    return `${contentNode}/content/${playlist.playlist_image_sizes_multihash}/1000x1000.jpg`
   } else if (playlist.playlist_image_multihash) {
-    return `${primaryEndpoint}/content/${playlist.playlist_image_multihash}`
+    return `${contentNode}/content/${playlist.playlist_image_multihash}`
   }
   return DEFAULT_PLAYLIST_IMAGE_URL
 }

--- a/apps/notifications/src/utils/env.ts
+++ b/apps/notifications/src/utils/env.ts
@@ -6,6 +6,12 @@ export const getHostname = () => {
   return 'https://audius.co'
 }
 
+const DEFAULT_CONTENT_NODE = 'https://api.audius.co'
+
 export const getContentNode = () => {
-  return 'https://creatornode2.audius.co'
+  return (
+    process.env.NOTIFICATIONS_CONTENT_NODE_ENDPOINT ||
+    process.env.CONTENT_NODE_ENDPOINT ||
+    DEFAULT_CONTENT_NODE
+  ).replace(/\/+$/, '')
 }


### PR DESCRIPTION
## Summary
- default notification image URLs to `https://api.audius.co` instead of a hard-coded creator node
- stop using stored `creator_node_endpoint` values for track and playlist email images
- add `NOTIFICATIONS_CONTENT_NODE_ENDPOINT` as a notification-specific override
- update notification mapping expectations to use the API content gateway

## Dependency
- depends on AudiusProject/api#985 being deployed before this is merged/released

## Testing
- `npm test -w @pedalboard/notifications -- --runInBand src/__tests__/contentNodeEnv.test.ts`
- `npm run typecheck -w @pedalboard/notifications`
- `git diff --check`

## Notes
- The broader notifications mapping/email Jest command still needs local discovery DB env and fails before assertions in `populateDB.ts`.
- Remaining `creatornode2.audius.co` references in archiver/backfill use non-`/content` APIs and were left for a separate follow-up.